### PR TITLE
Bump vllm to 0.17.0 for Qwen3.5 support

### DIFF
--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -30,7 +30,7 @@ jobs:
             target: chat
             cuda_version: "13.0.2"
             torch_cuda_arch_list: "8.0 8.6 8.7 8.9 9.0 10.0 12.0 12.1"
-            vllm_version: "0.15.1"
+            vllm_version: "0.17.0"
             cuda_toolkit: "cu130"
             platforms: linux/amd64,linux/arm64
 
@@ -38,7 +38,7 @@ jobs:
             target: serve
             cuda_version: "13.0.2"
             torch_cuda_arch_list: "8.0 8.6 8.7 8.9 9.0 10.0 12.0 12.1"
-            vllm_version: "0.15.1"
+            vllm_version: "0.17.0"
             cuda_toolkit: "cu130"
             platforms: linux/amd64,linux/arm64
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ transformers = [
     "autoawq",
 ]
 vllm = [
-    "vllm>=0.15",
+    "vllm>=0.17",
     "accelerate",
 ]
 mlx = [


### PR DESCRIPTION
## Summary
- Update vllm minimum version from 0.15 to 0.17 in pyproject.toml
- Update Docker CI matrix to build with vllm 0.17.0 wheels

## Test plan
- [ ] Trigger Docker build workflow and verify images build successfully
- [ ] Test serve CLI with Qwen3.5 model

Made with [Cursor](https://cursor.com)