### PR TITLE
Add agent CLI, Qwen3.5 vLLM support, and Docker improvements

### DIFF
--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -30,7 +30,7 @@ jobs:
             target: chat
             cuda_version: "13.0.2"
             torch_cuda_arch_list: "8.0 8.6 8.7 8.9 9.0 10.0 12.0 12.1"
-            vllm_version: "0.15.1"
+            vllm_version: "0.17.0"
             cuda_toolkit: "cu130"
             platforms: linux/amd64,linux/arm64
 
@@ -38,7 +38,7 @@ jobs:
             target: serve
             cuda_version: "13.0.2"
             torch_cuda_arch_list: "8.0 8.6 8.7 8.9 9.0 10.0 12.0 12.1"
-            vllm_version: "0.15.1"
+            vllm_version: "0.17.0"
             cuda_toolkit: "cu130"
             platforms: linux/amd64,linux/arm64
 

--- a/README.md
+++ b/README.md
@@ -19,35 +19,55 @@ State-of-the-art INT4 quantization for LLMs. ParoQuant uses learned pairwise rot
 
 ## Quick Start
 
-### Interactive Chat
+### Installation
 
 ```bash
 # NVIDIA GPU
 pip install "paroquant[vllm]"
-python -m paroquant.cli.chat --model z-lab/Qwen3-8B-PARO
 
 # Apple Silicon
 pip install "paroquant[mlx]"
-python -m paroquant.cli.chat --model z-lab/Qwen3-8B-PARO
+```
+
+Pick a model from our [Hugging Face collection](https://huggingface.co/collections/z-lab/paroquant):
+
+```bash
+export MODEL=z-lab/Qwen3.5-4B-PARO
+```
+
+### Interactive Chat
+
+```bash
+python -m paroquant.cli.chat --model $MODEL
 ```
 
 ### OpenAI-Compatible API Server
 
 ```bash
-pip install "paroquant[vllm]"
-python -m paroquant.cli.serve --model z-lab/Qwen3-8B-PARO
+python -m paroquant.cli.serve --model $MODEL --port 8000
 ```
 
-### Docker
+### Agent with Tool Calling
+
+Start the API server first, then install the agent dependencies and run:
+
+```bash
+pip install "paroquant[agent]"
+python -m paroquant.cli.agent --model $MODEL
+```
+
+Tool use (web fetch, filesystem, time) requires [uv](https://docs.astral.sh/uv/) and [Node.js](https://nodejs.org/en/download).
+
+### Docker (NVIDIA GPU)
 
 ```bash
 # Interactive chat
 docker run --pull=always --rm -it --gpus all --ipc=host \
-  ghcr.io/z-lab/paroquant:chat --model z-lab/Qwen3-8B-PARO
+  ghcr.io/z-lab/paroquant:chat --model $MODEL
 
 # API server (port 8000)
 docker run --pull=always --rm -it --gpus all --ipc=host -p 8000:8000 \
-  ghcr.io/z-lab/paroquant:serve --model z-lab/Qwen3-8B-PARO
+  ghcr.io/z-lab/paroquant:serve --model $MODEL
 ```
 
 ## Models

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -55,6 +55,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
         pip install -e ".[vllm]"; \
     fi
 ENV TRITON_PTXAS_PATH=/usr/local/cuda/bin/ptxas
+ENV TRITON_PTXAS_BLACKWELL_PATH=/usr/local/cuda/bin/ptxas
 ENTRYPOINT ["python", "-m", "paroquant.cli.chat"]
 
 # ---- serve: OpenAI-compatible vLLM API server ----
@@ -72,6 +73,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
         pip install -e ".[vllm]"; \
     fi
 ENV TRITON_PTXAS_PATH=/usr/local/cuda/bin/ptxas
+ENV TRITON_PTXAS_BLACKWELL_PATH=/usr/local/cuda/bin/ptxas
 ENTRYPOINT ["python", "-m", "paroquant.cli.serve"]
 
 # ---- optim: optimization & evaluation ----

--- a/paroquant/cli/agent.py
+++ b/paroquant/cli/agent.py
@@ -1,0 +1,308 @@
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import re
+import tempfile
+import time
+import warnings
+
+from qwen_agent.agents import Assistant
+from rich.console import Console
+from rich.live import Live
+from rich.markdown import Markdown
+from rich.panel import Panel
+from rich.theme import Theme
+
+_SPECIAL_RE = re.compile(r"<\|[^|]+\|>")
+_THINK_RE = re.compile(r"^.*?</think>\n?", re.DOTALL)
+_THINKING_LINES = 4
+
+SYSTEM_PROMPT = """\
+You are ParoQuant Agent, a helpful AI assistant powered by a local quantized model.
+You have access to tools that let you interact with the real world:
+- Get the current time in any timezone
+- Fetch and read web pages
+- Read, write, and list files in the workspace directory
+Use tools when the user's request requires real-world information or actions.
+Be concise in your final answers."""
+
+
+def _suppress_library_noise():
+    os.environ["PYTHONWARNINGS"] = "ignore"
+    warnings.filterwarnings("ignore")
+    logging.disable(logging.CRITICAL)
+
+
+def _make_agent(server: str, model: str, workspace: str) -> Assistant:
+    llm_cfg = {
+        "model": model,
+        "model_type": "qwenvl_oai",
+        "model_server": server,
+        "api_key": os.environ.get("OPENAI_API_KEY", "EMPTY"),
+        "generate_cfg": {
+            "timeout": 120,
+            "max_retries": 1,
+            "temperature": 0.7,
+            "top_p": 0.8,
+            "presence_penalty": 1.5,
+            "extra_body": {
+                "top_k": 20,
+                "min_p": 0.0,
+                "repetition_penalty": 1.0,
+                "chat_template_kwargs": {"enable_thinking": False},
+            },
+        },
+    }
+
+    mcp_servers = {
+        "time": {"command": "uvx", "args": ["mcp-server-time", "--local-timezone=US/Pacific"]},
+        "fetch": {"command": "uvx", "args": ["mcp-server-fetch"]},
+        "filesystem": {"command": "npx", "args": ["-y", "@modelcontextprotocol/server-filesystem", workspace]},
+    }
+
+    tools: list = []
+    try:
+        import mcp  # noqa: F401
+
+        tools = [{"mcpServers": mcp_servers}]
+    except ImportError:
+        pass
+
+    return Assistant(
+        llm=llm_cfg,
+        function_list=tools or None,
+        name="ParoQuant Agent",
+        description="Agent powered by a local ParoQuant quantized model with tool calling.",
+        system_message=SYSTEM_PROMPT,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Response parsing helpers
+# ---------------------------------------------------------------------------
+
+
+def _clean(text: str) -> str:
+    return _THINK_RE.sub("", _SPECIAL_RE.sub("", text)).strip()
+
+
+def _get_thinking(text: str) -> str | None:
+    if "<think>" in text and "</think>" not in text:
+        return text.split("<think>", 1)[1]
+    return None
+
+
+def _friendly_tool_name(name: str) -> str:
+    parts = name.split("-", 1)
+    return parts[1] if len(parts) > 1 else name
+
+
+def _format_tool_args(args_json: str) -> str:
+    try:
+        return ", ".join(f"{k}={v}" for k, v in json.loads(args_json).items())
+    except (json.JSONDecodeError, TypeError, AttributeError):
+        return args_json or ""
+
+
+def _last_msg_with(msgs: list[dict], *, role: str = "", key: str = "") -> tuple[dict | None, int]:
+    """Return the last message matching role/key and its index, or (None, -1)."""
+    for i in reversed(range(len(msgs))):
+        m = msgs[i]
+        if not isinstance(m, dict):
+            continue
+        if role and m.get("role") != role:
+            continue
+        if key and not m.get(key):
+            continue
+        return m, i
+    return None, -1
+
+
+def _thinking_panel(width: int, text: str, elapsed: float) -> Panel:
+    tail = "\n".join(text.splitlines()[-_THINKING_LINES:])
+    return Panel(
+        tail or "...",
+        title=f"thinking ({elapsed:.1f}s)",
+        border_style="dim",
+        width=min(width, 80),
+        height=_THINKING_LINES + 2,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Main loop
+# ---------------------------------------------------------------------------
+
+
+def main():
+    _suppress_library_noise()
+
+    parser = argparse.ArgumentParser(description="ParoQuant Agent")
+    parser.add_argument("--server", type=str, default="http://127.0.0.1:8000/v1")
+    parser.add_argument("--model", type=str, required=True)
+    parser.add_argument("--workspace", type=str, default=None)
+    args = parser.parse_args()
+
+    workspace = args.workspace or tempfile.mkdtemp(prefix="paroquant-agent-")
+    console = Console(theme=Theme({"hint": "dim", "tool": "cyan"}))
+
+    console.print("[hint]Connecting to model server and initializing tools...[/hint]")
+    agent = _make_agent(args.server, args.model, workspace)
+
+    console.print("[hint]Warming up...[/hint]")
+    warmup = _make_agent(args.server, args.model, workspace)
+    for _ in warmup.run(messages=[{"role": "user", "content": "Hi"}]):
+        pass
+    del warmup
+
+    console.clear()
+
+    console.print(
+        Panel.fit(
+            f"[bold]ParoQuant Agent[/bold]\n"
+            f"Model: [bold]{args.model}[/bold]\n"
+            f"Server: [bold]{args.server}[/bold]\n\n"
+            f"[bold]/clear[/bold] · [bold]/quit[/bold]",
+            border_style="bright_blue",
+        )
+    )
+
+    messages: list[dict] = []
+
+    while True:
+        try:
+            user_input = console.input(">>> ").strip()
+        except (KeyboardInterrupt, EOFError):
+            console.print("\n[hint]Session closed.[/hint]")
+            break
+        if not user_input:
+            continue
+        if user_input.lower() in {"/quit", "quit", "/exit", "exit"}:
+            break
+        if user_input.lower() == "/clear":
+            messages.clear()
+            console.clear()
+            console.print("[hint]Conversation history cleared.[/hint]\n")
+            continue
+
+        messages.append({"role": "user", "content": user_input})
+
+        last_response: list[dict] = []
+        final_content = ""
+        turn_start = time.perf_counter()
+        live: Live | None = None
+        phase = "idle"
+        seen_tool_idx = seen_resp_idx = -1
+        tool_time = 0.0
+        tool_timer_start: float | None = None
+
+        try:
+            for response in agent.run(messages=messages):
+                if not isinstance(response, list):
+                    continue
+                last_response = response
+                elapsed = time.perf_counter() - turn_start
+
+                # Detect new tool call
+                tc_msg, tc_idx = _last_msg_with(response, key="function_call")
+                if tc_idx > seen_tool_idx and tc_idx == len(response) - 1:
+                    seen_tool_idx = tc_idx
+                    tool_timer_start = time.perf_counter()
+                    phase = "tool"
+                    continue
+
+                # Detect new tool response
+                _, resp_idx = _last_msg_with(response, role="function")
+                if resp_idx > seen_resp_idx and resp_idx == len(response) - 1:
+                    seen_resp_idx = resp_idx
+                    if tool_timer_start is not None:
+                        tool_time += time.perf_counter() - tool_timer_start
+                        tool_timer_start = None
+                    continue
+
+                # Tool call completed — print summary and move on
+                if phase == "tool" and tc_msg is not None and tc_idx != len(response) - 1:
+                    if live:
+                        live.stop()
+                        live = None
+                    fc = tc_msg["function_call"]
+                    name = _friendly_tool_name(fc.get("name", ""))
+                    console.print(f"  [tool]> {name}({_format_tool_args(fc.get('arguments', ''))})[/tool]")
+                    resp_msg, _ = _last_msg_with(response, role="function")
+                    if resp_msg:
+                        text = resp_msg.get("content", "").replace("\n", " ")
+                        if len(text) > 100:
+                            text = text[:100] + "..."
+                        console.print(f"    [hint]{text}[/hint]")
+                    phase = "generating"
+
+                # Extract latest assistant content
+                asst_msg, _ = _last_msg_with(response, role="assistant")
+                raw = (asst_msg or {}).get("content", "")
+                if not raw:
+                    continue
+
+                # Show thinking box
+                thinking = _get_thinking(raw)
+                if thinking is not None:
+                    if phase != "thinking":
+                        if live:
+                            live.stop()
+                        live = Live(console=console, transient=True)
+                        live.start()
+                        phase = "thinking"
+                    live.update(_thinking_panel(console.width, thinking, elapsed))
+                    continue
+
+                # Stream answer
+                content = _clean(raw)
+                if not content or content == final_content:
+                    continue
+                if phase != "answering":
+                    if live:
+                        live.stop()
+                    live = Live(Markdown(content), console=console, vertical_overflow="visible")
+                    live.start()
+                    phase = "answering"
+                else:
+                    live.update(Markdown(content))
+                final_content = content
+
+        except Exception as e:
+            if live:
+                live.stop()
+            console.print(f"[red]Error: {e}[/red]\n")
+            messages.pop()
+            continue
+
+        if live:
+            if final_content:
+                live.update(Markdown(final_content))
+            live.stop()
+
+        if not final_content:
+            asst_msg, _ = _last_msg_with(last_response, role="assistant")
+            final_content = _clean((asst_msg or {}).get("content", ""))
+            if final_content:
+                console.print(Markdown(final_content))
+
+        if tool_timer_start is not None:
+            tool_time += time.perf_counter() - tool_timer_start
+
+        total = time.perf_counter() - turn_start
+        stats = []
+        if tool_time > 0:
+            stats.append(f"tools {tool_time:.1f}s")
+        stats.append(f"{total:.1f}s total")
+        console.print(f"  {' · '.join(stats)}", style="hint", highlight=False)
+
+        if last_response:
+            messages.extend(last_response)
+        console.print()
+
+
+if __name__ == "__main__":
+    main()

--- a/paroquant/cli/chat.py
+++ b/paroquant/cli/chat.py
@@ -147,6 +147,11 @@ async def run_chat_app(model: str, backend: str, params: GenerationParams):
 
     console.print(f"[hint]Loading model ({backend})...[/hint]")
     generator = create_generator(backend, model)
+
+    console.print("[hint]Warming up...[/hint]")
+    warmup_prompt = build_prompt(generator.tokenizer, [{"role": "user", "content": "Hi"}], False)
+    await generator.generate(warmup_prompt, GenerationParams(max_tokens=1, temperature=0.0))
+
     console.clear()
 
     enable_thinking = False

--- a/paroquant/cli/serve.py
+++ b/paroquant/cli/serve.py
@@ -1,21 +1,49 @@
 from __future__ import annotations
 
-import asyncio
-import sys
+from paroquant.inference.base import detect_backend
 
-from vllm.entrypoints.openai.api_server import (
-    FlexibleArgumentParser,
-    make_arg_parser,
-    run_server,
-)
 
-import paroquant.inference.backends.vllm.plugin  # noqa: F401 — registers quantization config
+def _serve_vllm():
+    import asyncio
+    import sys
+
+    from vllm.entrypoints.openai.api_server import (
+        FlexibleArgumentParser,
+        make_arg_parser,
+        run_server,
+    )
+
+    import paroquant.inference.backends.vllm.plugin  # noqa: F401
+
+    args = make_arg_parser(FlexibleArgumentParser()).parse_args(sys.argv[1:])
+    asyncio.run(run_server(args))
+
+
+def _serve_mlx():
+    import mlx_lm.server
+    from mlx_lm.utils import load_tokenizer
+
+    from paroquant.inference.backends.mlx.load import load as paro_load
+
+    def _patched_load(path_or_hf_repo, tokenizer_config=None, adapter_path=None, **kwargs):
+        model, _, _ = paro_load(path_or_hf_repo, force_text=True)
+        tokenizer = load_tokenizer(path_or_hf_repo, tokenizer_config_extra=tokenizer_config)
+        tokenizer._tool_call_start = None
+        tokenizer._tool_call_end = None
+        return model, tokenizer
+
+    mlx_lm.server.load = _patched_load
+    mlx_lm.server.main()
 
 
 def main():
-    parser = make_arg_parser(FlexibleArgumentParser())
-    args = parser.parse_args(sys.argv[1:])
-    asyncio.run(run_server(args))
+    backend = detect_backend()
+    if backend in ("vllm", "transformers"):
+        _serve_vllm()
+    elif backend == "mlx":
+        _serve_mlx()
+    else:
+        raise RuntimeError(f"Serve requires vllm or mlx. Detected: {backend}")
 
 
 if __name__ == "__main__":

--- a/paroquant/inference/backends/mlx/load.py
+++ b/paroquant/inference/backends/mlx/load.py
@@ -148,7 +148,7 @@ def _is_io_layer(path, module):
     return hasattr(module, "to_quantized") and (path.endswith("embed_tokens") or path.endswith("lm_head"))
 
 
-def load(model_path: str, lazy: bool = False) -> tuple:
+def load(model_path: str, lazy: bool = False, force_text: bool = False) -> tuple:
     """Load a ParoQuant model for MLX. Returns (model, processor, is_vlm)."""
     from huggingface_hub import snapshot_download
 
@@ -165,7 +165,7 @@ def load(model_path: str, lazy: bool = False) -> tuple:
     paro = config.get("quantization_config", {})
     group_size = int(paro.get("group_size", 128))
     bits = int(paro.get("bits", 4))
-    is_vlm = "vision_config" in config
+    is_vlm = "vision_config" in config and not force_text
 
     model = _create_model(config, is_vlm)
 

--- a/paroquant/inference/backends/vllm/plugin.py
+++ b/paroquant/inference/backends/vllm/plugin.py
@@ -26,6 +26,7 @@ logger = init_logger(__name__)
 
 _SHARD_INDEX = {"q": 0, "k": 1, "v": 2}
 _QUANT_TYPE = {4: scalar_types.uint4}
+_MARLIN_TILE_N = 64
 
 
 def _rotation_weight_loader(
@@ -103,15 +104,25 @@ class ParoQuantConfig(QuantizationConfig):
 
         unquant_dtypes = [torch.float16, torch.bfloat16, torch.float32]
         metadata = get_safetensors_params_metadata(model_name, revision=revision)
-        all_layers = {k.rsplit(".", 1)[0] for k in metadata}
-        quant_layers: set[str] = {
+
+        # Only consider leaf modules (those with ".weight"), not containers
+        # that have scalar FP16 params (e.g. A_log) which would false-match.
+        leaf_modules = {k.rsplit(".", 1)[0] for k in metadata if k.endswith(".weight")}
+        quant_modules: set[str] = {
             k.rsplit(".", 1)[0]
             for k, info in metadata.items()
             if (dt := info.get("dtype")) and _SF_DTYPES[dt] not in unquant_dtypes
         }
-        # Strip "model." prefix so names match vLLM's internal module prefixes
-        # (safetensors keys use "model.X" but vLLM's get_quant_method receives "X").
-        self.modules_to_not_convert = [k.removeprefix("model.") for k in (all_layers - quant_layers)]
+        # Strip to "layers.N..." suffix so vLLM's substr matching works
+        # regardless of model nesting depth (safetensors may store
+        # "model.language_model.layers.0.X" while vLLM uses
+        # "language_model.model.layers.0.X").
+        def _strip(name: str) -> str:
+            name = name.removeprefix("model.")
+            i = name.find("layers.")
+            return name[i:] if i >= 0 else name
+
+        self.modules_to_not_convert = [_strip(k) for k in leaf_modules - quant_modules]
 
     def get_quant_method(self, layer: torch.nn.Module, prefix: str) -> LinearMethodBase | None:
         if not isinstance(layer, LinearBase):
@@ -170,6 +181,15 @@ class ParoQuantLinearMethod(AWQMarlinLinearMethod):
 
     def _convert_partition(self, qw, sc, qz, k, out_n, num_groups):
         """AWQ→Marlin conversion for a single partition via the parent method."""
+        # Pad output dim to Marlin tile boundary when needed.
+        if out_n % _MARLIN_TILE_N != 0:
+            pad = _MARLIN_TILE_N - out_n % _MARLIN_TILE_N
+            pack = self.quant_config.pack_factor
+            qw = torch.nn.functional.pad(qw, (0, pad // pack))
+            sc = torch.nn.functional.pad(sc, (0, pad))
+            qz = torch.nn.functional.pad(qz, (0, pad // pack))
+            out_n += pad
+
         proxy = torch.nn.Module()
         proxy.register_parameter("qweight", Parameter(qw.contiguous(), requires_grad=False))
         proxy.register_parameter("scales", Parameter(sc.contiguous(), requires_grad=False))
@@ -203,6 +223,7 @@ class ParoQuantLinearMethod(AWQMarlinLinearMethod):
             layer.workspace = proxies[0].workspace
             layer.g_idx = proxies[0].g_idx
             layer.g_idx_sort_indices = proxies[0].g_idx_sort_indices
+            layer.padded_partition_sizes = [p.output_size_per_partition for p in proxies]
 
         layer.rot_theta = layer.theta.data
         layer.rot_pairs = layer.pairs.data
@@ -219,21 +240,22 @@ class ParoQuantLinearMethod(AWQMarlinLinearMethod):
         outputs = []
         for i in range(n):
             x_rot = torch.ops.rotation.rotate(x, layer.rot_pairs[i], layer.rot_theta[i], layer.rot_scales[i])
-            outputs.append(
-                apply_awq_marlin_linear(
-                    input=x_rot,
-                    weight=layer.marlin_qweight[i],
-                    weight_scale=layer.marlin_scales[i],
-                    weight_zp=layer.marlin_qzeros[i],
-                    g_idx=layer.g_idx,
-                    g_idx_sort_indices=layer.g_idx_sort_indices,
-                    workspace=layer.workspace,
-                    quant_type=self.quant_config.quant_type,
-                    output_size_per_partition=layer.output_partition_sizes[i],
-                    input_size_per_partition=layer.input_size_per_partition,
-                    bias=None,
-                )
+            out = apply_awq_marlin_linear(
+                input=x_rot,
+                weight=layer.marlin_qweight[i],
+                weight_scale=layer.marlin_scales[i],
+                weight_zp=layer.marlin_qzeros[i],
+                g_idx=layer.g_idx,
+                g_idx_sort_indices=layer.g_idx_sort_indices,
+                workspace=layer.workspace,
+                quant_type=self.quant_config.quant_type,
+                output_size_per_partition=layer.padded_partition_sizes[i],
+                input_size_per_partition=layer.input_size_per_partition,
+                bias=None,
             )
+            if layer.padded_partition_sizes[i] != layer.output_partition_sizes[i]:
+                out = out[..., :layer.output_partition_sizes[i]]
+            outputs.append(out)
 
         result = torch.cat(outputs, dim=-1)
         if bias is not None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "paroquant"
-version = "0.1.3"
+version = "0.1.4"
 requires-python = ">=3.11"
 description = "ParoQuant — Pairwise Rotation Quantization for LLMs"
 readme = "README.md"
@@ -44,6 +44,11 @@ optim = [
 eval = [
     "lm_eval",
     "zstandard",
+]
+agent = [
+    "qwen-agent",
+    "mcp",
+    "soundfile",
 ]
 dev = [
     "pytest",


### PR DESCRIPTION
## Summary

- **Agent CLI**: New `paroquant.cli.agent` with MCP tool calling (web fetch, filesystem, time), warmup request for kernel compilation
- **Qwen3.5 vLLM fix**: Pad Marlin partitions to 64-tile boundary for small output dims; fix `modules_to_not_convert` detection for hybrid Mamba architectures (leaf-module-only filtering + nesting-agnostic suffix matching)
- **Serve CLI**: Unified `paroquant.cli.serve` auto-detecting vLLM/MLX backend
- **Docker**: Bump vLLM to 0.17.0, add `TRITON_PTXAS_BLACKWELL_PATH` for Jetson Thor
- **README**: Qwen3.5 examples, agent section, install notes
- **pyproject.toml**: Add `agent` optional dependency group

Supersedes #6.

## Test plan

- [x] `paroquant.cli.serve` with `z-lab/Qwen3.5-4B-PARO` on vLLM 0.17 (RTX PRO 6000 Blackwell)
- [x] `paroquant.cli.serve` with `z-lab/Qwen3-8B-PARO` on vLLM 0.17
- [x] Verified Marlin tile padding triggers and trims correctly
- [x] Verified `modules_to_not_convert` detects leaf modules only, no false matches on container modules
- [x] Agent CLI tested with MCP tools on MLX backend

Made with [Cursor](https://cursor.com)