### PR TITLE
Fix AutoAWQ -> MLX scales and bias dtype mismatch. Fixes #33.

### DIFF
--- a/paroquant/inference/backends/mlx/load.py
+++ b/paroquant/inference/backends/mlx/load.py
@@ -48,9 +48,9 @@ def _convert_awq_linear(weights: dict, prefix: str, group_size: int) -> dict:
     qw = np.array(weights[f"{prefix}qweight"])
     weight = mx.array(_pack_mlx(_unpack_and_reorder(qw).T))
     scales_np = np.array(weights[f"{prefix}scales"]).astype(np.float32)
-    scales = mx.array(scales_np.T.copy())
+    scales = mx.array(scales_np.astype(np.float16).T.copy())
     zeros = _unpack_and_reorder(np.array(weights[f"{prefix}qzeros"])).astype(np.float32)
-    biases = mx.array((-scales_np * zeros).T.copy().astype(np.float16))
+    biases = mx.array((-scales_np * zeros).astype(np.float16).T.copy())
     return {"weight": weight, "scales": scales, "biases": biases}
 
 


### PR DESCRIPTION
`_convert_awq_linear` emitted `fp32` scales and `fp16` biases, but `mx.quantized_matmul` requires matching dtypes for the pair.  This  mismatch produced NaN logits on Apple Silicon, causing generation to stream token 0 ("!") for AutoAWQ paroquant checkpoints.

Text generation works fine after applying this 2 line fix.
<img width="406" height="180" alt="image" src="https://github.com/user-attachments/assets/e6ee967c-fe03-4893-b3bc-a03c5268b760" />