### PR TITLE
Update optimization pipeline for Gemma 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ All models are available on [Hugging Face](https://huggingface.co/collections/z-
 | Model          | Checkpoint                                                                      |
 | -------------- | ------------------------------------------------------------------------------- |
 | gemma-4-31B-it | [`z-lab/gemma-4-31B-it-PARO`](https://huggingface.co/z-lab/gemma-4-31B-it-PARO) |
+| gemma-4-E4B-it | [`z-lab/gemma-4-E4B-it-PARO`](https://huggingface.co/z-lab/gemma-4-E4B-it-PARO) |
 | gemma-4-E2B-it | [`z-lab/gemma-4-E2B-it-PARO`](https://huggingface.co/z-lab/gemma-4-E2B-it-PARO) |
 
 **Qwen3.6**

--- a/assets/model_card.jinja
+++ b/assets/model_card.jinja
@@ -7,6 +7,8 @@ license: {{ license }}
 {% if pipeline_tag -%} pipeline_tag: {{ pipeline_tag }} {%- endif %}
 base_model:
 - {{ base_model }}
+tags:
+  - mlx
 ---
 
 # {{ paro_model_path }}
@@ -50,13 +52,24 @@ python -m paroquant.cli.chat --model {{ paro_model_path }}
 
 ### OpenAI-Compatible API Server
 
+For vLLM, you can directly use `vllm serve` to serve ParoQuant models:
+
 ```bash
-python -m paroquant.cli.serve --model {{ paro_model_path }} --port 8000
+vllm serve $MODEL --port 8000
 ```
 
-For vLLM, the arguments are passed to the vLLM server directly. See [vLLM docs](https://docs.vllm.ai/en/latest/configuration/serve_args/) for more details.
+For other frameworks:
 
+```bash
+python -m paroquant.cli.serve --model $MODEL --port 8000
+```
+
+{% if pipeline_tag == "image-text-to-text" -%}
 For MLX, add `--vlm` if you wish to load the VLM components and use the model's multimodal features. For vLLM, VLM components are loaded by default and can be skipped with the server argument `--language-model-only`.
+
+> [!NOTE]
+> The visual components in this checkpoint is stored in original precision, and only the language components are quantized to 4 bits; as a result, the model size is larger than a fully-quantized model. Avoid loading the VLM components if you are not using the multimodal features for the best efficiency.
+{%- endif %}
 
 ### Docker (NVIDIA GPU)
 

--- a/experiments/optimize/4bit.sh
+++ b/experiments/optimize/4bit.sh
@@ -10,16 +10,20 @@ fi
 python3 -m paroquant.cli.optimize \
     --model $model_path \
     --params "channel_scales:0.05,angles:0.05" "weight:1e-5,quantizer:1e-6" \
-    --epochs 10 10 \
+    --epochs 5 5 \
     --group-size 128 \
     --n-bit 4 \
     --num-rotations 8 \
+    --skipped-modules \
+        "mlp.gate" "mlp.shared_expert_gate" \
+        "mlp.shared_expert.up_proj" "mlp.shared_expert.gate_proj" "mlp.shared_expert.down_proj" \
+        "linear_attn.in_proj_a" "linear_attn.in_proj_b" \
     --datasets wikitext2 c4 redpajama \
-    --skipped-modules "linear_attn.in_proj_a" "linear_attn.in_proj_b" \
     --val-dataset pileval \
     --train-size 2048 \
     --validation-size 64 \
     --batch-size 16 \
+    --gradient-accumulation-steps 1 \
     --seqlen 2048 \
     --cache-shards $shards \
     --output-dir ./output \

--- a/paroquant/cli/convert.py
+++ b/paroquant/cli/convert.py
@@ -11,9 +11,8 @@ from typing import Any
 import torch
 from tqdm import tqdm
 from transformers import AutoModelForCausalLM, AutoModelForImageTextToText
-from transformers.models.qwen3_5_moe.modeling_qwen3_5_moe import Qwen3_5MoeExperts
 
-from paroquant.optim.qexperts import PseudoQuantizedQwen3_5MoeExperts, get_named_qwen3_5_moe_experts
+from paroquant.optim.qexperts import PseudoQuantizedMoEExperts, get_named_moe_experts, is_fused_moe_experts
 from paroquant.optim.util import get_named_linears, set_module_by_name
 
 
@@ -214,7 +213,7 @@ def _convert_pseudo(model: torch.nn.Module, result_dir: Path) -> int:
         layer = layer.cuda()
         modules: dict[str, torch.nn.Module] = {}
         modules.update(get_named_linears(layer))
-        modules.update(get_named_qwen3_5_moe_experts(layer))
+        modules.update(get_named_moe_experts(layer))
 
         for name, module in modules.items():
             pt_file = result_dir / f"{layer_idx}.{name}.pt"
@@ -226,8 +225,8 @@ def _convert_pseudo(model: torch.nn.Module, result_dir: Path) -> int:
                 module.weight.data.copy_(qlinear.pseudo_weight())
                 if module.bias is not None and qlinear.bias is not None:
                     module.bias.data.copy_(qlinear.bias.data)
-            elif isinstance(module, Qwen3_5MoeExperts):
-                qexperts = PseudoQuantizedQwen3_5MoeExperts.from_state_dict(sd, module, "cuda")
+            elif is_fused_moe_experts(module):
+                qexperts = PseudoQuantizedMoEExperts.from_state_dict(sd, module, "cuda")
                 module.gate_up_proj.data.copy_(qexperts.gate_up_proj.data)
                 module.down_proj.data.copy_(qexperts.down_proj.data)
             else:
@@ -439,7 +438,7 @@ def _convert_real(
             set_module_by_name(layer, name, rl)
             count += 1
 
-        for name, module in get_named_qwen3_5_moe_experts(layer).items():
+        for name, module in get_named_moe_experts(layer).items():
             pt_file = result_dir / f"{layer_idx}.{name}.pt"
             if not pt_file.exists():
                 continue

--- a/paroquant/cli/optimize.py
+++ b/paroquant/cli/optimize.py
@@ -11,11 +11,10 @@ import torch
 import torch.nn as nn
 import wandb
 from tqdm import tqdm
-from transformers.models.qwen3_5_moe.modeling_qwen3_5_moe import Qwen3_5MoeExperts
 
 from paroquant.optim.train import optimize_module, get_random_rotation_pairs
 from paroquant.optim.qlinear import PseudoQuantizedLinear
-from paroquant.optim.qexperts import PseudoQuantizedQwen3_5MoeExperts, get_named_qwen3_5_moe_experts
+from paroquant.optim.qexperts import PseudoQuantizedMoEExperts, get_named_moe_experts, is_fused_moe_experts
 from paroquant.optim.util import (
     set_module_by_name,
     load_model,
@@ -134,7 +133,7 @@ def main():
         json.dump(vars(args), f, indent=2)
 
     # Load model.
-    model = load_model(args.model, device_map="cpu", dtype=torch.float16)
+    model = load_model(args.model, device_map="cpu", dtype=torch.float16).half()
     move_embed(model, device)
     tokenizer = load_tokenizer(args.model)
     blocks = get_blocks(model)
@@ -212,7 +211,7 @@ def main():
             for key in RETAINED_KWARG_KEYS:
                 if key in retained_kwargs_batches[batch_idx]:
                     batch_kwargs[key] = to_device(retained_kwargs_batches[batch_idx][key], device)
-            output = layer(*(arg.to(device=device) for arg in args_batch), **batch_kwargs)
+            output = layer(*to_device(args_batch, device), **batch_kwargs)
             if isinstance(output, tuple):
                 output = output[0]
             if output.device != store_device:
@@ -233,12 +232,6 @@ def main():
         return [
             (input_batch, *other_args_batch) for input_batch, other_args_batch in zip(input_batches, other_args_batches)
         ]
-
-    def get_named_optim_modules(layer: nn.Module) -> dict[str, nn.Module]:
-        modules: dict[str, nn.Module] = {}
-        modules.update(get_named_linears(layer))
-        modules.update(get_named_qwen3_5_moe_experts(layer))
-        return modules
 
     def init_rotation_data(
         weight: torch.Tensor,
@@ -316,14 +309,18 @@ def main():
         train_args_batches = CachedTensorShards(train_args_batches, args.cache_shards, target_device=device)
         train_output_batches = CachedTensorShards(train_output_batches, args.cache_shards, target_device=device)
 
-        val_args_batches = [tuple(arg.to(device) for arg in args_batch) for args_batch in layer_val_args_batches]
+        val_args_batches = [to_device(args_batch, device) for args_batch in layer_val_args_batches]
         val_output_batches = [b.to(device) for b in og_layer_val_output_batches]
 
         # Freeze all parameters
         for param in layer.parameters():
             param.requires_grad = False
 
-        optim_modules = get_named_optim_modules(layer)
+        linear_modules = get_named_linears(layer)
+        expert_modules = get_named_moe_experts(layer)
+        optim_modules: dict[str, nn.Module] = {}
+        optim_modules.update(linear_modules)
+        optim_modules.update(expert_modules)
         if args.resume:
             all_files_exist = True
             for name in optim_modules.keys():
@@ -338,10 +335,14 @@ def main():
         if not all_files_exist:
             logger.info(f"Initializing rotation parameters...")
 
-        modules_names_to_optimize = [name for name in optim_modules.keys() if name not in args.skipped_modules]
-        skipped_module_names = [name for name in optim_modules.keys() if name in args.skipped_modules]
-        logger.info(f"Modules to optimize: {modules_names_to_optimize}")
-        logger.info(f"Skipped modules: {skipped_module_names}")
+        linear_names_to_optimize = [name for name in linear_modules.keys() if name not in args.skipped_modules]
+        expert_names_to_optimize = [name for name in expert_modules.keys() if name not in args.skipped_modules]
+        skipped_linear_names = [name for name in linear_modules.keys() if name in args.skipped_modules]
+        skipped_expert_names = [name for name in expert_modules.keys() if name in args.skipped_modules]
+        logger.info(f"Linear modules to optimize: {linear_names_to_optimize}")
+        logger.info(f"MoE expert modules to optimize: {expert_names_to_optimize}")
+        logger.info(f"Skipped linear modules: {skipped_linear_names}")
+        logger.info(f"Skipped MoE expert modules: {skipped_expert_names}")
 
         named_pseudo_modules: dict[str, nn.Module] = {}
         for name, old_module in optim_modules.items():
@@ -354,8 +355,8 @@ def main():
                 if isinstance(old_module, nn.Linear):
                     new_module = PseudoQuantizedLinear.from_state_dict(sd)
                     set_module_by_name(layer, name, new_module)
-                elif isinstance(old_module, Qwen3_5MoeExperts):
-                    new_module = PseudoQuantizedQwen3_5MoeExperts.from_state_dict(sd, old_module, device)
+                elif is_fused_moe_experts(old_module):
+                    new_module = PseudoQuantizedMoEExperts.from_state_dict(sd, old_module, device)
                     set_module_by_name(layer, name, new_module)
                 else:
                     raise NotImplementedError(f"Unsupported module type: {type(old_module)}")
@@ -382,7 +383,7 @@ def main():
                     num_rotations=args.num_rotations,
                 )
                 set_module_by_name(layer, name, new_module)
-            elif isinstance(old_module, Qwen3_5MoeExperts):
+            elif is_fused_moe_experts(old_module):
                 gate_up = old_module.gate_up_proj.float().view(-1, old_module.gate_up_proj.shape[-1])
                 down = old_module.down_proj.float().view(-1, old_module.down_proj.shape[-1])
                 gate_up_rotation_pairs = init_rotation_data(
@@ -410,7 +411,7 @@ def main():
                     device=device,
                 )
 
-                new_module = PseudoQuantizedQwen3_5MoeExperts(
+                new_module = PseudoQuantizedMoEExperts(
                     old_module,
                     gate_up_rotation_pairs,
                     down_rotation_pairs,

--- a/paroquant/cli/optimize.py
+++ b/paroquant/cli/optimize.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from copy import deepcopy
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Literal
@@ -23,11 +24,13 @@ from paroquant.optim.util import (
     get_blocks,
     get_calib_dataset,
     get_mixed_calib_dataset,
-    catch_first_layer_input_and_all_layer_kwargs,
+    capture_layer_inputs_and_args,
     get_named_linears,
     empty_cache,
     logger,
     CachedTensorShards,
+    RETAINED_KWARG_KEYS,
+    to_device,
 )
 from paroquant.optim.rotation import transform_to_kernel_data
 
@@ -157,23 +160,37 @@ def main():
     )
     val_samples = torch.stack(val_samples, dim=0).to(device)
 
-    # Capture first layer's input.
-    logger.info("Capturing first layer input and layer kwargs...")
-    blocks[0].to(device)
-    og_layer_input_batches, kwargs_list = catch_first_layer_input_and_all_layer_kwargs(
+    # Capture per-batch positional args and layer kwargs.
+    logger.info("Capturing layer positional args and kwargs...")
+    model.to(device)
+    (
+        og_layer_input_batches,
+        kwargs_list,
+        other_args_batches_list,
+        og_retained_kwargs_batches,
+    ) = capture_layer_inputs_and_args(
         model,
         blocks,
         samples,
         batch_size=args.batch_size,
     )
+
     val_batch_size = args.val_batch_size or args.batch_size
-    og_layer_val_input_batches, _ = catch_first_layer_input_and_all_layer_kwargs(
+    (
+        og_layer_val_input_batches,
+        val_kwargs_list,
+        val_other_args_batches_list,
+        og_val_retained_kwargs_batches,
+    ) = capture_layer_inputs_and_args(
         model,
         blocks,
         val_samples,
         batch_size=val_batch_size,
     )
-    blocks[0].cpu()
+    new_retained_kwargs_batches = deepcopy(og_retained_kwargs_batches)
+    new_val_retained_kwargs_batches = deepcopy(og_val_retained_kwargs_batches)
+
+    model.cpu()
 
     del samples
     empty_cache()
@@ -181,24 +198,41 @@ def main():
     @torch.no_grad()
     def forward_layer_batch(
         layer: nn.Module,
-        input_batched: list[torch.Tensor],
+        args_batched: list[tuple[torch.Tensor, ...]],
+        *,
         kwargs: dict,
-        store_device: torch.device,
+        retained_kwargs_batches: list[dict],
+        store_device: torch.device | str,
     ) -> list[torch.Tensor]:
         output_batched = []
 
         layer.to(device)
-        for input_batch in input_batched:
-            output = layer(input_batch.to(device=device), **kwargs)
+        for batch_idx, args_batch in enumerate(args_batched):
+            batch_kwargs = kwargs.copy()
+            for key in RETAINED_KWARG_KEYS:
+                if key in retained_kwargs_batches[batch_idx]:
+                    batch_kwargs[key] = to_device(retained_kwargs_batches[batch_idx][key], device)
+            output = layer(*(arg.to(device=device) for arg in args_batch), **batch_kwargs)
             if isinstance(output, tuple):
                 output = output[0]
             if output.device != store_device:
                 output = output.to(store_device)
             output_batched.append(output)
+            for key in RETAINED_KWARG_KEYS:
+                if key in batch_kwargs:
+                    retained_kwargs_batches[batch_idx][key] = to_device(batch_kwargs[key], "cpu")
         layer.cpu()
 
         empty_cache()
         return output_batched
+
+    def make_layer_args_batches(
+        input_batches: list[torch.Tensor],
+        other_args_batches: list[tuple[torch.Tensor, ...]],
+    ) -> list[tuple[torch.Tensor, ...]]:
+        return [
+            (input_batch, *other_args_batch) for input_batch, other_args_batch in zip(input_batches, other_args_batches)
+        ]
 
     def get_named_optim_modules(layer: nn.Module) -> dict[str, nn.Module]:
         modules: dict[str, nn.Module] = {}
@@ -240,27 +274,49 @@ def main():
         empty_cache()
         logger.info(f"Capturing original layer output...")
         # Original output of this layer.
+        og_layer_args_batches = make_layer_args_batches(
+            og_layer_input_batches,
+            other_args_batches_list[layer_idx],
+        )
+        og_layer_val_args_batches = make_layer_args_batches(
+            og_layer_val_input_batches,
+            val_other_args_batches_list[layer_idx],
+        )
         og_layer_output_batches = forward_layer_batch(
-            layer, og_layer_input_batches, kwargs_list[layer_idx], store_device="cpu"
+            layer,
+            og_layer_args_batches,
+            kwargs=kwargs_list[layer_idx],
+            retained_kwargs_batches=og_retained_kwargs_batches,
+            store_device="cpu",
         )
         og_layer_val_output_batches = forward_layer_batch(
-            layer, og_layer_val_input_batches, kwargs_list[layer_idx], store_device="cpu"
+            layer,
+            og_layer_val_args_batches,
+            kwargs=val_kwargs_list[layer_idx],
+            retained_kwargs_batches=og_val_retained_kwargs_batches,
+            store_device="cpu",
         )
 
         if layer_idx > 0:
-            layer_input_batches = new_layer_output_batches
-            layer_val_input_batches = new_layer_val_output_batches
+            layer_args_batches = make_layer_args_batches(
+                new_layer_output_batches,
+                other_args_batches_list[layer_idx],
+            )
+            layer_val_args_batches = make_layer_args_batches(
+                new_layer_val_output_batches,
+                val_other_args_batches_list[layer_idx],
+            )
         else:
-            layer_input_batches = og_layer_input_batches
-            layer_val_input_batches = og_layer_val_input_batches
+            layer_args_batches = og_layer_args_batches
+            layer_val_args_batches = og_layer_val_args_batches
 
-        train_input_batches = layer_input_batches
+        train_args_batches = layer_args_batches
         train_output_batches = og_layer_output_batches
 
-        train_input_batches = CachedTensorShards(train_input_batches, args.cache_shards, target_device=device)
+        train_args_batches = CachedTensorShards(train_args_batches, args.cache_shards, target_device=device)
         train_output_batches = CachedTensorShards(train_output_batches, args.cache_shards, target_device=device)
 
-        val_input_batches = [b.to(device) for b in layer_val_input_batches]
+        val_args_batches = [tuple(arg.to(device) for arg in args_batch) for args_batch in layer_val_args_batches]
         val_output_batches = [b.to(device) for b in og_layer_val_output_batches]
 
         # Freeze all parameters
@@ -399,6 +455,16 @@ def main():
                     if hasattr(pseudo_module, "reset_angles_by_mask"):
                         pseudo_module.reset_angles_by_mask()
 
+            train_kwargs_batches = [
+                kwargs_list[layer_idx] | {k: retained_kwargs[k] for k in RETAINED_KWARG_KEYS if k in retained_kwargs}
+                for retained_kwargs in new_retained_kwargs_batches
+            ]
+            val_kwargs_batches = [
+                val_kwargs_list[layer_idx]
+                | {k: retained_kwargs[k] for k in RETAINED_KWARG_KEYS if k in retained_kwargs}
+                for retained_kwargs in new_val_retained_kwargs_batches
+            ]
+
             for step, step_params_dict in enumerate(params_to_optimize):
                 empty_cache()
                 optim_params = []
@@ -424,9 +490,10 @@ def main():
 
                 layer_step = optimize_module(
                     layer,
-                    (train_input_batches, train_output_batches),
-                    (val_input_batches, val_output_batches),
-                    kwargs_list[layer_idx],
+                    (train_args_batches, train_output_batches),
+                    (val_args_batches, val_output_batches),
+                    train_kwargs_batches,
+                    val_kwargs_batches,
                     optim_params,
                     loss_fn=args.loss,
                     n_iter=args.epochs[step],
@@ -440,9 +507,9 @@ def main():
             set_checkpointing_enabled(named_pseudo_modules, False)
 
             del (
-                train_input_batches,
+                train_args_batches,
                 train_output_batches,
-                val_input_batches,
+                val_args_batches,
                 val_output_batches,
             )
             empty_cache()
@@ -455,14 +522,16 @@ def main():
         logger.info("Capturing new layer output...")
         new_layer_output_batches = forward_layer_batch(
             layer,
-            layer_input_batches,
-            kwargs_list[layer_idx],
+            layer_args_batches,
+            kwargs=kwargs_list[layer_idx],
+            retained_kwargs_batches=new_retained_kwargs_batches,
             store_device="cpu",
         )
         new_layer_val_output_batches = forward_layer_batch(
             layer,
-            layer_val_input_batches,
-            kwargs_list[layer_idx],
+            layer_val_args_batches,
+            kwargs=val_kwargs_list[layer_idx],
+            retained_kwargs_batches=new_val_retained_kwargs_batches,
             store_device="cpu",
         )
 

--- a/paroquant/kernels/cuda/rotation.cu
+++ b/paroquant/kernels/cuda/rotation.cu
@@ -117,10 +117,9 @@ torch::Tensor rotate_dynamic(at::Tensor x, at::Tensor idx, at::Tensor theta,
   if (group_size == 128) {
     DISPATCH_KROT(128)
   }
-  // We also drop support for group_size=64 here to speed up compilation.
-  // if (group_size == 64) {
-  //   DISPATCH_KROT(64)
-  // }
+  if (group_size == 64) {
+    DISPATCH_KROT(64)
+  }
   TORCH_CHECK(false, "Unsupported group_size: ", group_size, "; expected 64 or 128");
 }
 

--- a/paroquant/optim/qexperts.py
+++ b/paroquant/optim/qexperts.py
@@ -7,25 +7,19 @@ import torch.nn as nn
 import torch.nn.functional as F
 from torch.utils.checkpoint import checkpoint
 
-from transformers.activations import ACT2FN
 from transformers.integrations.moe import ALL_EXPERTS_FUNCTIONS
-from transformers.models.qwen3_5_moe.modeling_qwen3_5_moe import Qwen3_5MoeExperts
 
 from paroquant.kernels.cuda import scaled_pairwise_rotation
 
 from .quantizer import UniformAffineQuantizer
 
 
-def get_named_qwen3_5_moe_experts(module: nn.Module) -> dict[str, Qwen3_5MoeExperts]:
-    return {name: m for name, m in module.named_modules() if isinstance(m, Qwen3_5MoeExperts)}
-
-
-class PseudoQuantizedQwen3_5MoeExperts(nn.Module):
-    """Pseudo-quantized fused MoE experts for Qwen3.5-MoE."""
+class PseudoQuantizedMoEExperts(nn.Module):
+    """Pseudo-quantized fused GLU MoE experts."""
 
     def __init__(
         self,
-        experts: Qwen3_5MoeExperts,
+        experts: nn.Module,
         gate_up_rotation_pairs: Optional[list[torch.Tensor]],
         down_rotation_pairs: Optional[list[torch.Tensor]],
         gate_up_channel_scales: Optional[torch.Tensor],
@@ -41,10 +35,10 @@ class PseudoQuantizedQwen3_5MoeExperts(nn.Module):
         self.num_experts = experts.num_experts
         self.hidden_dim = experts.hidden_dim
         self.intermediate_dim = experts.intermediate_dim
-        self.act_fn = ACT2FN[self.config.hidden_act]
+        self.act_fn = experts.act_fn
 
         # Keep compatibility with current transformers grouped expert interfaces.
-        self.has_gate = getattr(experts, "has_gate", False)
+        self.has_gate = experts.has_gate
         self.has_bias = False
         self.is_transposed = False
 
@@ -351,9 +345,9 @@ class PseudoQuantizedQwen3_5MoeExperts(nn.Module):
     def from_state_dict(
         cls,
         state_dict: dict,
-        template: Qwen3_5MoeExperts,
+        template: nn.Module,
         device: torch.device | str,
-    ) -> "PseudoQuantizedQwen3_5MoeExperts":
+    ) -> "PseudoQuantizedMoEExperts":
         target_device = torch.device(device)
         target_dtype = template.gate_up_proj.dtype
 
@@ -416,8 +410,35 @@ class PseudoQuantizedQwen3_5MoeExperts(nn.Module):
         return module
 
 
+def is_fused_moe_experts(module: nn.Module) -> bool:
+    if isinstance(module, PseudoQuantizedMoEExperts):
+        return False
+
+    required_attrs = ("config", "num_experts", "hidden_dim", "intermediate_dim", "act_fn", "gate_up_proj", "down_proj")
+    if not all(hasattr(module, attr) for attr in required_attrs):
+        return False
+
+    gate_up_proj = module.gate_up_proj
+    down_proj = module.down_proj
+    if not isinstance(gate_up_proj, torch.Tensor) or not isinstance(down_proj, torch.Tensor):
+        return False
+    if gate_up_proj.ndim != 3 or down_proj.ndim != 3:
+        return False
+    if gate_up_proj.shape[0] != down_proj.shape[0]:
+        return False
+    if module.num_experts != gate_up_proj.shape[0]:
+        return False
+    if gate_up_proj.shape[-1] != down_proj.shape[-2]:
+        return False
+    return gate_up_proj.shape[-2] == 2 * down_proj.shape[-1]
+
+
+def get_named_moe_experts(module: nn.Module) -> dict[str, nn.Module]:
+    return {name: m for name, m in module.named_modules() if is_fused_moe_experts(m)}
+
+
 @torch.no_grad()
 def reset_moe_angles_by_mask(module: nn.Module) -> None:
     for submodule in module.modules():
-        if isinstance(submodule, PseudoQuantizedQwen3_5MoeExperts):
+        if isinstance(submodule, PseudoQuantizedMoEExperts):
             submodule.reset_angles_by_mask()

--- a/paroquant/optim/qlinear.py
+++ b/paroquant/optim/qlinear.py
@@ -25,12 +25,11 @@ class PseudoQuantizedLinear(nn.Module):
     ) -> None:
         super().__init__()
         self.enable_checkpoint = False
-        self.weight = nn.Parameter(linear.weight.clone())
+        self.weight = nn.Parameter(linear.weight.half().clone())
         self.in_feat = self.weight.shape[1]
         self.out_feat = self.weight.shape[0]
         num_groups = self.in_feat // group_size
         assert self.in_feat % group_size == 0
-        assert self.weight.dtype == torch.float16 or self.weight.dtype == torch.float32
         if rotation_pairs is not None:
             pairs_grouped, angles_grouped, mask = rotation_pairs
             assert pairs_grouped.size(0) == num_rotations

--- a/paroquant/optim/train.py
+++ b/paroquant/optim/train.py
@@ -10,7 +10,7 @@ import torch
 import torch.nn as nn
 from tqdm import tqdm
 
-from .util import CosineAnnealingParam, logger
+from .util import CosineAnnealingParam, RETAINED_KWARG_KEYS, logger, to_device
 
 
 def _get_independent_channel_pairs(
@@ -93,9 +93,10 @@ def get_random_rotation_pairs(
 
 def optimize_module(
     module: nn.Module,
-    train_set_batches: tuple[Iterator[torch.Tensor], Iterator[torch.Tensor]],
-    val_set_batches: tuple[Iterator[torch.Tensor], Iterator[torch.Tensor]],
-    kwargs: dict,
+    train_set_batches: tuple[Iterator[tuple[torch.Tensor, ...]], Iterator[torch.Tensor]],
+    val_set_batches: tuple[Iterator[tuple[torch.Tensor, ...]], Iterator[torch.Tensor]],
+    train_kwargs: dict | list[dict],
+    val_kwargs: dict | list[dict],
     optim_params: list[dict],
     *,
     loss_fn: Literal["mse", "smooth_l1"],
@@ -106,13 +107,13 @@ def optimize_module(
     metric_logger: Callable[[dict[str, float], int], None] | None = None,
     start_step: int = 0,
 ) -> int:
-    train_input_batches, train_output_batches = train_set_batches
-    val_input_batches, val_output_batches = val_set_batches
+    train_args_batches, train_output_batches = train_set_batches
+    val_args_batches, val_output_batches = val_set_batches
 
     if gradient_accumulation_steps <= 0:
         raise ValueError(f"gradient_accumulation_steps must be a positive integer, got {gradient_accumulation_steps}")
 
-    num_train_batches = len(train_input_batches)
+    num_train_batches = len(train_args_batches)
     total_steps = n_iter * math.ceil(num_train_batches / gradient_accumulation_steps)
     schedulers = [
         CosineAnnealingParam(
@@ -133,26 +134,37 @@ def optimize_module(
 
     progress_bar = tqdm(total=n_iter, unit="iter")
 
-    def module_output(input: torch.Tensor) -> torch.Tensor:
-        out = module(input, **kwargs)
+    def module_output(args: tuple[torch.Tensor, ...], kwargs: dict | list[dict], batch_idx: int) -> torch.Tensor:
+        batch_kwargs = kwargs
+        if isinstance(kwargs, list):
+            batch_kwargs = {
+                key: value.copy() if isinstance(value, dict) else value for key, value in kwargs[batch_idx].items()
+            }
+            for key in RETAINED_KWARG_KEYS:
+                if key in batch_kwargs:
+                    batch_kwargs[key] = to_device(batch_kwargs[key], args[0].device)
+        out = module(*args, **batch_kwargs)
         if isinstance(out, tuple):
             out = out[0]
         return out
 
     @torch.no_grad()
-    def loss_batches(input_batches: Iterator[torch.Tensor], output_batches: Iterator[torch.Tensor]) -> torch.Tensor:
+    def val_loss_batches(
+        args_batches: Iterator[tuple[torch.Tensor, ...]],
+        output_batches: Iterator[torch.Tensor],
+    ) -> torch.Tensor:
         total_loss = None
-        for input_batch, output_batch in zip(input_batches, output_batches):
-            output_q = module_output(input_batch)
+        for batch_idx, (args_batch, output_batch) in enumerate(zip(args_batches, output_batches)):
+            output_q = module_output(args_batch, val_kwargs, batch_idx)
             loss_value = loss(output_batch, output_q)
             if total_loss is None:
                 total_loss = loss_value
             else:
                 total_loss += loss_value
-        return total_loss / len(input_batches)
+        return total_loss / len(args_batches)
 
     with torch.no_grad(), torch.amp.autocast("cuda"):
-        original_val_loss = loss_batches(val_input_batches, val_output_batches)
+        original_val_loss = val_loss_batches(val_args_batches, val_output_batches)
 
     best_val_loss = original_val_loss
     best_sd = deepcopy(module.state_dict())
@@ -173,8 +185,8 @@ def optimize_module(
         accum_counter = 0
         accum_loss = 0.0
         window_size = min(gradient_accumulation_steps, num_train_batches)
-        for batch_idx, (input_batch, output_batch) in enumerate(
-            zip(train_input_batches, train_output_batches),
+        for batch_idx, (args_batch, output_batch) in enumerate(
+            zip(train_args_batches, train_output_batches),
             start=1,
         ):
             if accum_counter == 0:
@@ -182,7 +194,7 @@ def optimize_module(
                 window_size = min(gradient_accumulation_steps, remaining_batches)
 
             with torch.amp.autocast("cuda"):
-                output_q = module_output(input_batch)
+                output_q = module_output(args_batch, train_kwargs, batch_idx - 1)
                 batch_loss = loss(output_batch, output_q)
                 loss_value = batch_loss / window_size
 
@@ -208,7 +220,7 @@ def optimize_module(
                 accum_loss = 0.0
 
         with torch.no_grad(), torch.amp.autocast("cuda"):
-            val_loss_value = loss_batches(val_input_batches, val_output_batches)
+            val_loss_value = val_loss_batches(val_args_batches, val_output_batches)
 
         if val_loss_value < best_val_loss:
             best_val_loss = val_loss_value

--- a/paroquant/optim/util.py
+++ b/paroquant/optim/util.py
@@ -12,7 +12,21 @@ import torch.nn as nn
 from datasets import load_dataset
 from tqdm import tqdm
 from transformers import AutoModelForCausalLM, AutoTokenizer, AutoConfig
-from contextlib import suppress
+
+
+RETAINED_KWARG_KEYS = ("shared_kv_states",)
+
+
+def to_device(value, device: torch.device | str):
+    if isinstance(value, torch.Tensor):
+        return value.to(device)
+    if isinstance(value, list):
+        return [to_device(v, device) for v in value]
+    if isinstance(value, tuple):
+        return tuple(to_device(v, device) for v in value)
+    if isinstance(value, dict):
+        return {k: to_device(v, device) for k, v in value.items()}
+    return value
 
 
 def get_blocks(model: nn.Module) -> nn.ModuleList:
@@ -75,11 +89,18 @@ def move_embed(model, device):
     else:
         raise NotImplementedError(type(model))
 
-    if hasattr(model, "embed_tokens"):
-        model.embed_tokens = model.embed_tokens.to(device)
+    def _move(module_name):
+        module = getattr(model, module_name, None)
+        if module is not None:
+            module.to(device)
 
-    if hasattr(model, "rotary_emb"):
-        model.rotary_emb = model.rotary_emb.to(device)
+    _move("embed_tokens")
+    _move("rotary_emb")
+
+    # Gemma 4
+    _move("embed_tokens_per_layer")
+    _move("per_layer_model_projection")
+    _move("per_layer_projection_norm")
 
 
 def empty_cache():
@@ -194,15 +215,17 @@ def get_calib_dataset(
 
 
 @torch.no_grad()
-def catch_first_layer_input_and_all_layer_kwargs(
+def capture_layer_inputs_and_args(
     model: nn.Module,
     layers: nn.ModuleList,
     samples: torch.Tensor,
     batch_size: int | None,
-) -> tuple[torch.Tensor, list[dict]]:
+) -> tuple[list[torch.Tensor], list[dict], list[list[tuple[torch.Tensor, ...]]], list[dict]]:
+    device = samples.device
     kwargs_list: list[dict] = [{} for _ in range(len(layers))]
-    batched = batch_size is not None
-    inps: list[torch.Tensor] = []
+    first_layer_input_batches: list[torch.Tensor] = []
+    other_args_batches_list: list[list[tuple[torch.Tensor, ...]]] = [[] for _ in range(len(layers))]
+    retained_kwargs_batches: list[dict] = []
 
     class Catcher(nn.Module):
 
@@ -212,28 +235,26 @@ def catch_first_layer_input_and_all_layer_kwargs(
             object.__setattr__(self, "module", module)
             object.__setattr__(self, "layer_idx", layer_idx)
 
-        def forward(self, inp, *args, **kwargs):
-            # We only capture the first input.
+        def forward(self, *args, **kwargs):
             if self.layer_idx == 0:
-                inps.append(inp)
+                first_layer_input_batches.append(args[0].cpu())
 
             # Capture kwargs for all layers.
             layer_kwargs = kwargs_list[self.layer_idx]
             if len(layer_kwargs) == 0:
-                layer_kwargs.update(kwargs)
+                layer_kwargs.update({k: v for k, v in kwargs.items() if k not in RETAINED_KWARG_KEYS})
                 layer_kwargs.pop("use_cache", None)
                 layer_kwargs.pop("past_key_value", None)
                 layer_kwargs.pop("past_key_values", None)
 
-            # Gemma 4 has an extra `per_layer_input` arg. Ignore it since it's only for multimodal tokens.
-            if len(args) > 0:
-                warnings.warn(f"Silently ignoring additional positional arguments in layer forward: {args}.")
+            other_args_batches_list[self.layer_idx].append(
+                tuple(arg.cpu() if isinstance(arg, torch.Tensor) else arg for arg in args[1:])
+            )
+            retained_kwargs = {k: to_device(kwargs[k], "cpu") for k in RETAINED_KWARG_KEYS if k in kwargs}
+            if self.layer_idx == 0:
+                retained_kwargs_batches.append(retained_kwargs)
 
-            if self.layer_idx == len(layers) - 1:
-                raise ValueError
-
-            # Return a dummy output
-            return torch.empty_like(inp)
+            return torch.empty_like(args[0], device=device)
 
         def __getattr__(self, name):
             return getattr(self.module, name)
@@ -241,39 +262,51 @@ def catch_first_layer_input_and_all_layer_kwargs(
     for layer_idx, layer in enumerate(layers):
         layers[layer_idx] = Catcher(layer, layer_idx)
 
-    batch_size = samples.shape[0] if not batched or batch_size <= 0 else batch_size
+    batch_size = samples.shape[0] if batch_size is None or batch_size <= 0 else batch_size
     num_batches = samples.shape[0] // batch_size
     samples_batch = samples.chunk(num_batches)
     for samples in samples_batch:
-        with suppress(ValueError):
-            model(samples.to(next(model.parameters()).device))
+        model(samples)
 
     for layer_idx, layer in enumerate(layers):
         layers[layer_idx] = layer.module
 
-    if not batched:
-        inps = inps[0]
+    return (
+        first_layer_input_batches,
+        kwargs_list,
+        other_args_batches_list,
+        retained_kwargs_batches,
+    )
 
-    return inps, kwargs_list
+
+def _move_tensor_batch(batch, device: torch.device | str) -> torch.Tensor | tuple[torch.Tensor, ...]:
+    return to_device(batch, device)
+
+
+def _tensor_batch_device(batch) -> torch.device:
+    if isinstance(batch, tuple):
+        return batch[0].device
+    return batch.device
 
 
 class CachedTensorShards:
+
     def __init__(
         self,
-        batches: list[torch.Tensor],
+        batches: list[torch.Tensor] | list[tuple[torch.Tensor, ...]],
         num_shards: int,
         *,
-        target_device: torch.device,
-        offload_device: torch.device = torch.device("cpu"),
+        target_device: torch.device | str,
+        offload_device: torch.device | str = torch.device("cpu"),
     ):
         assert len(batches) % num_shards == 0
-        if batches[0].device != offload_device:
-            self.batches = [b.to(offload_device) for b in batches]
+        if _tensor_batch_device(batches[0]) != offload_device:
+            self.batches = [_move_tensor_batch(b, offload_device) for b in batches]
         else:
             self.batches = batches
         self.num_shards = num_shards
         self.current_shard: int = None
-        self.cached_shard: list[torch.Tensor] = None
+        self.cached_shard: list[torch.Tensor] | list[tuple[torch.Tensor, ...]] = None
         self.target_device = target_device
 
     def _switch_shard(self, shard_index: int) -> None:
@@ -282,7 +315,7 @@ class CachedTensorShards:
         self.current_shard = shard_index
         start, end = self._get_shard_range(shard_index)
         self.cached_shard = self.batches[start:end]
-        self.cached_shard = [b.to(self.target_device) for b in self.cached_shard]
+        self.cached_shard = [_move_tensor_batch(b, self.target_device) for b in self.cached_shard]
 
     def _get_shard_range(self, index: int) -> tuple[int, int]:
         if self.num_shards == 1:
@@ -295,7 +328,7 @@ class CachedTensorShards:
             end = shard_size * (index + 1)
         return start, end
 
-    def __getitem__(self, index: int) -> torch.Tensor:
+    def __getitem__(self, index: int) -> torch.Tensor | tuple[torch.Tensor, ...]:
         shard_len = len(self.batches) // self.num_shards
         shard_index = index // shard_len
         if self.current_shard != shard_index:
@@ -317,7 +350,7 @@ class CachedTensorShards:
         def __iter__(self):
             return self
 
-        def __next__(self) -> torch.Tensor:
+        def __next__(self) -> torch.Tensor | tuple[torch.Tensor, ...]:
             if self.current_index >= len(self.batches):
                 raise StopIteration
             result = self.batches[self.current_index]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "paroquant"
-version = "0.1.14"
+version = "0.1.15"
 requires-python = ">=3.11"
 description = "ParoQuant — Pairwise Rotation Quantization for LLMs"
 readme = "README.md"


### PR DESCRIPTION
## Summary

This PR targets Gemma 4 support, including adaptations for the per-layer input, shared KV states, and MoE support.

### Gemma 4 E2B and E4B support

This updates the layer-wise optimization pipeline for Gemma 4 models by replaying each layer with its captured positional args and per-batch retained kwargs. In particular, mutable retained kwargs such as `shared_kv_states` are now carried forward per batch during replay instead of being treated as static layer kwargs.

The capture pass still avoids full layer computation by returning dummy outputs from the catcher, while recording the first-layer inputs, per-layer extra args, static kwargs, and initial retained kwargs needed for later replay.

### MoE support (#40)

Currently the optimization script only supports Qwen3.5 MoE models. Refactored the framework to handle MoE optimization in a generalized manner.

## Changes

- Add generic `to_device` support for tensors, lists, tuples, and dicts.
- Capture Gemma 4 layer args/kwargs with `capture_layer_inputs_and_args`.
- Replay original and quantized layers with full positional args plus per-batch retained kwargs.
- Update `optimize_module` and `CachedTensorShards` to support tuple args.
- Move Gemma 4 embed/projection modules during optimization setup.
- Update Gemma 4 optimization script defaults and model documentation.