### PR TITLE
Fix gemma-4 MoE experts loading unquantized (float32) → load OOM

### DIFF
--- a/paroquant/inference/backends/mlx/load.py
+++ b/paroquant/inference/backends/mlx/load.py
@@ -178,6 +178,37 @@ def _remap_shared_moe_rotation(weights: dict) -> dict:
     return weights
 
 
+def _align_moe_to_model(weights: dict, model) -> dict:
+    """Rename stacked MoE keys onto the model's actual MoE module path.
+
+    ``_stack_moe_expert_weights``/``_remap_shared_moe_rotation`` emit keys under a
+    ``switch_mlp`` namespace (the Qwen convention). Architectures that name the MoE
+    module differently — e.g. gemma-4 uses ``experts.switch_glu`` — would otherwise
+    never match a module: ``load_weights(strict=False)`` silently drops the stacked
+    quantized weights, leaving the experts as their unquantized float32 init (which
+    blows peak memory ~4x, e.g. 16GB -> >90GB for gemma-4-26B-A4B). Remap each
+    ``<base>.switch_mlp.<rest>`` key onto the SwitchGLU path under ``<base>``. No-op
+    when the model already uses ``switch_mlp``.
+    """
+    sg_paths = [p for p, mod in model.named_modules() if type(mod).__name__ == "SwitchGLU"]
+    if not sg_paths:
+        return weights
+
+    marker = ".switch_mlp."
+    for key in list(weights):
+        i = key.find(marker)
+        if i < 0:
+            continue
+        base = key[:i]
+        if f"{base}.switch_mlp" in sg_paths:
+            continue  # model already uses switch_mlp (e.g. Qwen)
+        target = next((p for p in sg_paths if p.startswith(base + ".")), None)
+        if target is None:
+            continue
+        weights[f"{target}.{key[i + len(marker):]}"] = weights.pop(key)
+    return weights
+
+
 def _create_model(config: dict, is_vlm: bool):
     """Instantiate model from config, dispatching to mlx_vlm or mlx_lm."""
     if is_vlm:
@@ -349,6 +380,7 @@ def load(model_path: str, lazy: bool = False, force_text: bool = False) -> tuple
 
     weights = _stack_moe_expert_weights(weights)
     weights = _remap_shared_moe_rotation(weights)
+    weights = _align_moe_to_model(weights, model)
     _patch_quantized_layers(model, weights, bits, group_size)
     model.load_weights(list(weights.items()), strict=False)
     mlx_nn.quantize(model, group_size, bits, mode="affine", class_predicate=_is_io_layer)


### PR DESCRIPTION
## Problem
`z-lab/gemma-4-26B-A4B-it-PARO` OOMs during load on <64GB Apple Silicon — it crashes on a 48GB machine even though the model is only ~16GB on disk. Reported in #46.

## Root cause
The conversion correctly produces 4-bit-packed expert weights, but `_stack_moe_expert_weights` / `_remap_shared_moe_rotation` emit them under a `switch_mlp.*` namespace (the Qwen convention). gemma-4's MLX MoE module is named `experts.switch_glu`, so the stacked quantized weights match no module and `load_weights(strict=False)` silently drops them. The 128 experts then keep their unquantized **float32** init:

- experts materialize as `float32 (128, 704, 2816)` — 90 tensors ≈ 91 GB
- model totals **93.5 GB** instead of ~15 GB → OOM (and the experts are uninitialized → wrong outputs)

## Fix
`_align_moe_to_model` renames stacked `<base>.switch_mlp.*` keys onto the model's actual `SwitchGLU` module path (discovered from `model.named_modules()`). No-op for models that already use `switch_mlp` (Qwen).

## Verification — gemma-4-26B-A4B-it-PARO, Apple Silicon, 48 GB
| | before | after |
|---|---|---|
| experts dtype | `float32 (128, 704, 2816)` | `uint32 (128, 704, 352)` (4-bit) |
| param total | 93.5 GB | 15.0 GB |
| load + decode peak | >60 GB (OOM) | 14.9 GB |
| output | (couldn't load) | coherent |

Qwen3.5 MoE unaffected (no-op path).

Fixes #46
