### PR TITLE
vllm: restore ParoQuant compatibility with vLLM 0.25.1

### DIFF
--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -30,7 +30,7 @@ jobs:
             target: chat
             cuda_version: "13.0.2"
             torch_cuda_arch_list: "8.0 8.6 8.7 8.9 9.0 10.0 12.0 12.1"
-            vllm_version: "0.19.1"
+            vllm_version: "0.25.1"
             cuda_toolkit: "cu130"
             platforms: linux/amd64,linux/arm64
 
@@ -38,7 +38,7 @@ jobs:
             target: serve
             cuda_version: "13.0.2"
             torch_cuda_arch_list: "8.0 8.6 8.7 8.9 9.0 10.0 12.0 12.1"
-            vllm_version: "0.19.1"
+            vllm_version: "0.25.1"
             cuda_toolkit: "cu130"
             platforms: linux/amd64,linux/arm64
 

--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ On Apple Silicon, we recommend serving ParoQuant models using [oMLX](https://git
 pip install "paroquant[vllm]"
 
 # NVIDIA GPU (CUDA 13.0)
-pip install "paroquant[vllm]" "vllm==0.19.1" \
-  --extra-index-url https://wheels.vllm.ai/0.19.1/cu130 \
+pip install "paroquant[vllm]" "vllm==0.25.1" \
+  --extra-index-url https://wheels.vllm.ai/0.25.1/cu130 \
   --extra-index-url https://download.pytorch.org/whl/cu130
 
 # Apple Silicon

--- a/assets/model_card.jinja
+++ b/assets/model_card.jinja
@@ -40,8 +40,8 @@ On Apple Silicon, we recommend serving ParoQuant models using [oMLX](https://git
 pip install "paroquant[vllm]"
 
 # NVIDIA GPU (CUDA 13.0)
-pip install "paroquant[vllm]" "vllm==0.19.1" \
-  --extra-index-url https://wheels.vllm.ai/0.19.1/cu130 \
+pip install "paroquant[vllm]" "vllm==0.25.1" \
+  --extra-index-url https://wheels.vllm.ai/0.25.1/cu130 \
   --extra-index-url https://download.pytorch.org/whl/cu130
 
 # Apple Silicon

--- a/paroquant/inference/backends/vllm/__init__.py
+++ b/paroquant/inference/backends/vllm/__init__.py
@@ -1,9 +1,18 @@
-from .generator import VllmGenerator
+from __future__ import annotations
 
-__all__ = ["VllmGenerator"]
+from typing import Any
+
+__all__ = ["VllmGenerator", "register"]
+
+
+def __getattr__(name: str) -> Any:
+    if name == "VllmGenerator":
+        from .generator import VllmGenerator
+
+        return VllmGenerator
+    raise AttributeError(name)
 
 
 def register() -> None:
     """vLLM general-plugin entry point. Idempotent."""
-    import paroquant.kernels.cuda  # noqa: F401 — registers torch.ops.rotation.rotate
     import paroquant.inference.backends.vllm.plugin  # noqa: F401 — registers ParoQuantConfig

--- a/paroquant/inference/backends/vllm/plugin.py
+++ b/paroquant/inference/backends/vllm/plugin.py
@@ -1,42 +1,93 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
-from copy import deepcopy
+
 import torch
 from torch.nn import Parameter
 from vllm.logger import init_logger
-from vllm.model_executor.layers.linear import LinearBase, LinearMethodBase, UnquantizedLinearMethod
+from vllm.model_executor.layers.linear import (
+    LinearBase,
+    LinearMethodBase,
+    UnquantizedLinearMethod,
+    register_weight_loader_v2_supported_method,
+)
 from vllm.model_executor.layers.quantization import register_quantization_config
-from vllm.model_executor.layers.quantization.awq_marlin import AWQMarlinLinearMethod
+from vllm.model_executor.layers.quantization.auto_awq import (
+    AutoAWQMarlinLinearMethod,
+)
 from vllm.model_executor.layers.quantization.base_config import QuantizationConfig
 from vllm.model_executor.layers.quantization.utils.marlin_utils import (
-    apply_awq_marlin_linear,
     check_marlin_supports_layer,
+    get_marlin_input_dtype,
 )
 from vllm.model_executor.layers.quantization.utils.quant_utils import is_layer_skipped
 from vllm.scalar_type import scalar_types
 from vllm.transformers_utils.config import get_safetensors_params_metadata
-from vllm.model_executor.parameter import PackedvLLMParameter, GroupQuantScaleParameter
-
-import paroquant.kernels.cuda  # noqa: F401 — registers torch.ops.rotation.rotate
 
 if TYPE_CHECKING:
+    from transformers import PretrainedConfig
     from vllm.model_executor.layers.quantization import QuantizationMethods
+    from vllm.model_executor.models.utils import WeightsMapper
 
 logger = init_logger(__name__)
 
 _SHARD_INDEX = {"q": 0, "k": 1, "v": 2}
 _QUANT_TYPE = {4: scalar_types.uint4}
-_MARLIN_TILE_N = 64
+_ROTATION_GROUP_SIZES = {64, 128}
+_ROTATION_COUNTS = {1, 8}
 
 
-def _maybe_shard_input(target: torch.Tensor, loaded_weight: torch.Tensor) -> torch.Tensor:
+class _PartitionLayerView:
+    """Expose one partition's root-owned kernel state under canonical names."""
+
+    def __init__(
+        self,
+        layer: torch.nn.Module,
+        tensor_names: dict[str, str],
+        values: dict[str, Any],
+    ) -> None:
+        self._layer = layer
+        self._tensor_names = tensor_names
+        self._values = values
+
+    def __getattr__(self, name: str) -> Any:
+        if name in self._tensor_names:
+            return getattr(self._layer, self._tensor_names[name])
+        if name in self._values:
+            return self._values[name]
+        raise AttributeError(name)
+
+    def refresh_values(self, other: _PartitionLayerView) -> None:
+        if self._tensor_names != other._tensor_names:
+            raise RuntimeError("ParoQuant partition state changed during reload.")
+        if self._values.keys() != other._values.keys():
+            raise RuntimeError("ParoQuant partition metadata changed during reload.")
+        for name, new_value in other._values.items():
+            old_value = self._values[name]
+            if type(old_value) is not type(new_value) or old_value != new_value:
+                raise RuntimeError(
+                    "ParoQuant partition metadata changed during reload: "
+                    f"attribute {name!r}."
+                )
+
+
+def _maybe_shard_input(
+    target: torch.Tensor, loaded_weight: torch.Tensor
+) -> torch.Tensor:
     """Slice loaded_weight along its last (input) dim if param is sharded for TP.
 
     Rotation params live along the linear layer's input dim. For row-parallel
     layers the param is allocated with input_size_per_partition = full // tp,
     while the on-disk weight is full size — slice it by tp_rank.
     """
+    if (
+        target.ndim != loaded_weight.ndim
+        or target.shape[:-1] != loaded_weight.shape[:-1]
+    ):
+        raise ValueError(
+            "ParoQuant rotation loader: incompatible shapes "
+            f"target={tuple(target.shape)} loaded={tuple(loaded_weight.shape)}"
+        )
     if target.shape[-1] == loaded_weight.shape[-1]:
         return loaded_weight
     if loaded_weight.shape[-1] % target.shape[-1] != 0:
@@ -44,9 +95,26 @@ def _maybe_shard_input(target: torch.Tensor, loaded_weight: torch.Tensor) -> tor
             f"ParoQuant rotation loader: incompatible shapes "
             f"target={tuple(target.shape)} loaded={tuple(loaded_weight.shape)}"
         )
-    from vllm.distributed import get_tensor_model_parallel_rank
+    from vllm.distributed import (
+        get_tensor_model_parallel_rank,
+        get_tensor_model_parallel_world_size,
+    )
+
     tp_rank = get_tensor_model_parallel_rank()
+    tp_world_size = get_tensor_model_parallel_world_size()
     shard = target.shape[-1]
+    num_shards = loaded_weight.shape[-1] // shard
+    if num_shards != tp_world_size:
+        raise ValueError(
+            "ParoQuant rotation loader: loaded tensor does not match the "
+            f"tensor-parallel world size (tensor shards={num_shards}, "
+            f"world size={tp_world_size})"
+        )
+    if tp_rank >= num_shards:
+        raise ValueError(
+            "ParoQuant rotation loader: tensor-parallel rank is outside the "
+            f"loaded tensor shards (rank={tp_rank}, shards={num_shards})"
+        )
     return loaded_weight.narrow(-1, tp_rank * shard, shard)
 
 
@@ -58,38 +126,63 @@ def _rotation_weight_loader(
     """Load per-projection rotation params into the partitioned param tensor.
 
     vLLM calls this with different shard_id types depending on the merge:
-      None         → single projection, copy directly
+      None         → single or pre-fused projection, copy to all targets
       "q"/"k"/"v"  → QKV merge, map to partition index 0/1/2
       int          → gate/up merge, use as partition index
       tuple        → fused projections (e.g. Qwen3.5), copy to each index
     """
     if loaded_shard_id is None:
-        target = param.data[0] if param.data.dim() > loaded_weight.dim() else param.data
-        target.copy_(_maybe_shard_input(target, loaded_weight))
+        if param.data.dim() == loaded_weight.dim() + 1:
+            for target in param.data:
+                target.copy_(_maybe_shard_input(target, loaded_weight))
+        else:
+            param.data.copy_(_maybe_shard_input(param.data, loaded_weight))
         return
 
     indices = (
-        loaded_shard_id if isinstance(loaded_shard_id, tuple) else (_SHARD_INDEX.get(loaded_shard_id, loaded_shard_id),)
+        loaded_shard_id
+        if isinstance(loaded_shard_id, tuple)
+        else (_SHARD_INDEX.get(loaded_shard_id, loaded_shard_id),)
     )
     for idx in indices:
+        if not isinstance(idx, int) or not 0 <= idx < param.data.shape[0]:
+            raise ValueError(
+                f"ParoQuant rotation loader: invalid shard id {loaded_shard_id!r} "
+                f"for {param.data.shape[0]} partitions"
+            )
         target = param.data[idx]
         target.copy_(_maybe_shard_input(target, loaded_weight))
 
 
 @register_quantization_config("paroquant")
 class ParoQuantConfig(QuantizationConfig):
-
-    def __init__(self, bits: int, group_size: int, krot: int, zero_point: bool) -> None:
+    def __init__(
+        self,
+        bits: int,
+        group_size: int,
+        krot: int,
+        zero_point: bool,
+        modules_to_not_convert: list[str] | None = None,
+    ) -> None:
         super().__init__()
         if bits not in _QUANT_TYPE:
             raise ValueError(f"Unsupported bits={bits}. Supported: {list(_QUANT_TYPE)}")
+        if group_size not in _ROTATION_GROUP_SIZES:
+            raise ValueError(
+                f"Unsupported group_size={group_size}. "
+                f"Supported: {sorted(_ROTATION_GROUP_SIZES)}"
+            )
+        if krot not in _ROTATION_COUNTS:
+            raise ValueError(
+                f"Unsupported krot={krot}. Supported: {sorted(_ROTATION_COUNTS)}"
+            )
         self.bits = bits
+        self.weight_bits = bits
         self.group_size = group_size
         self.krot = krot
         self.pack_factor = 32 // bits
         self.quant_type = _QUANT_TYPE[bits]
-        # We rely on the existance of `qweight` etc. to determin the skipped layers.
-        self.modules_to_not_convert = None
+        self.modules_to_not_convert = modules_to_not_convert
         self.zero_point = zero_point
 
     def __repr__(self) -> str:
@@ -118,57 +211,74 @@ class ParoQuantConfig(QuantizationConfig):
             group_size=cls.get_from_keys_or(config, ["group_size"], 128),
             krot=cls.get_from_keys_or(config, ["krot"], 8),
             zero_point=cls.get_from_keys_or(config, ["zero_point"], True),
+            modules_to_not_convert=cls.get_from_keys_or(
+                config, ["modules_to_not_convert"], None
+            ),
         )
 
-    def maybe_update_config(self, model_name: str, revision: str | None = None):
+    def maybe_update_config(
+        self,
+        model_name: str,
+        hf_config: PretrainedConfig | None = None,
+        revision: str | None = None,
+    ) -> None:
         """Auto-detect unquantized layers from safetensors metadata."""
-        if self.modules_to_not_convert:
+        if self.modules_to_not_convert is not None:
             return
 
-        from safetensors.torch import _TYPES as _SF_DTYPES
-
-        unquant_dtypes = [torch.float16, torch.bfloat16, torch.float32]
         metadata = get_safetensors_params_metadata(model_name, revision=revision)
 
         # Only consider leaf modules (those with ".weight"), not containers
         # that have scalar FP16 params (e.g. A_log) which would false-match.
         leaf_modules = {k.rsplit(".", 1)[0] for k in metadata if k.endswith(".weight")}
-        quant_modules: set[str] = {
-            k.rsplit(".", 1)[0]
-            for k, info in metadata.items()
-            if (dt := info.get("dtype")) and _SF_DTYPES[dt] not in unquant_dtypes
+        quant_modules = {
+            k.removesuffix(".qweight") for k in metadata if k.endswith(".qweight")
         }
 
-        # Strip to "layers.N..." suffix so vLLM's substr matching works
-        # regardless of model nesting depth (safetensors may store
-        # "model.language_model.layers.0.X" while vLLM uses
-        # "language_model.model.layers.0.X").
-        def _strip(name: str) -> str:
-            name = name.removeprefix("model.")
-            i = name.find("layers.")
-            return name[i:] if i >= 0 else name
+        # Preserve checkpoint names here. vLLM applies the model's unstacked
+        # WeightsMapper after metadata discovery, including multimodal prefixes.
+        self.modules_to_not_convert = sorted(leaf_modules - quant_modules)
 
-        self.modules_to_not_convert = [_strip(k) for k in leaf_modules - quant_modules]
+    def apply_vllm_mapper(self, hf_to_vllm_mapper: WeightsMapper) -> None:
+        if self.modules_to_not_convert:
+            self.modules_to_not_convert = hf_to_vllm_mapper.apply_list(
+                self.modules_to_not_convert
+            )
 
-    def get_quant_method(self, layer: torch.nn.Module, prefix: str) -> LinearMethodBase | None:
+    def get_quant_method(
+        self, layer: torch.nn.Module, prefix: str
+    ) -> LinearMethodBase | None:
         if not isinstance(layer, LinearBase):
             return None
-        if is_layer_skipped(prefix, self.modules_to_not_convert, self.packed_modules_mapping, skip_with_substr=True):
+        if is_layer_skipped(
+            prefix,
+            self.modules_to_not_convert or [],
+            self.packed_modules_mapping,
+            skip_with_substr=True,
+        ):
             return UnquantizedLinearMethod()
-        if not check_marlin_supports_layer(layer, self.group_size):
-            logger.warning_once(
-                "Layer '%s' is not supported by Marlin. Falling back to unquantized.",
-                prefix,
+        if not check_marlin_supports_layer(
+            layer, self.group_size, allow_tile_padding=True
+        ):
+            raise ValueError(
+                f"Quantized ParoQuant layer {prefix!r} cannot be sharded without "
+                "splitting a quantization group across tensor-parallel ranks."
             )
-            return UnquantizedLinearMethod()
-        return ParoQuantLinearMethod(self)
+        quant_method = ParoQuantLinearMethod(self)
+        quant_method.input_dtype = get_marlin_input_dtype(prefix)
+        return quant_method
 
 
-class ParoQuantLinearMethod(AWQMarlinLinearMethod):
+@register_weight_loader_v2_supported_method
+class ParoQuantLinearMethod(AutoAWQMarlinLinearMethod):
     """Per-projection rotation followed by AWQ-Marlin INT4 matmul."""
 
     def __init__(self, quant_config: ParoQuantConfig) -> None:
+        import paroquant.kernels.cuda  # noqa: F401
+
         super().__init__(quant_config)
+        self._partition_kernels: list[Any] = []
+        self._partition_views: list[_PartitionLayerView] = []
 
     def create_weights(
         self,
@@ -191,6 +301,37 @@ class ParoQuantLinearMethod(AWQMarlinLinearMethod):
         )
 
         n_parts = len(output_partition_sizes)
+        if input_size_per_partition % self.quant_config.group_size != 0:
+            raise ValueError(
+                "ParoQuant rotation requires input_size_per_partition to be "
+                f"divisible by group_size, got {input_size_per_partition} and "
+                f"{self.quant_config.group_size}."
+            )
+        if input_size_per_partition % 2 != 0:
+            raise ValueError(
+                "ParoQuant rotation requires an even input dimension, got "
+                f"{input_size_per_partition}."
+            )
+        if any(size % self.quant_config.pack_factor for size in output_partition_sizes):
+            raise ValueError(
+                "ParoQuant output partitions must be divisible by the packing "
+                f"factor {self.quant_config.pack_factor}: {output_partition_sizes}."
+            )
+
+        full_partition_sizes = getattr(layer, "output_sizes", None)
+        if full_partition_sizes is None:
+            if n_parts != 1:
+                raise ValueError(
+                    "Multipart ParoQuant layers must expose their full logical "
+                    "output sizes through layer.output_sizes."
+                )
+            full_partition_sizes = [output_size]
+        if len(full_partition_sizes) != n_parts:
+            raise ValueError(
+                "ParoQuant logical partition metadata does not match local "
+                f"partitions: full={full_partition_sizes}, local={output_partition_sizes}."
+            )
+
         krot = self.quant_config.krot
         for name, shape, dtype in [
             ("theta", (n_parts, krot, input_size_per_partition // 2), torch.float16),
@@ -202,108 +343,230 @@ class ParoQuantLinearMethod(AWQMarlinLinearMethod):
             p.weight_loader = _rotation_weight_loader
             layer.register_parameter(name, p)
 
-        layer.num_partitions = n_parts
-        layer.output_partition_sizes = output_partition_sizes
+        layer.paro_num_partitions = n_parts
+        layer.paro_output_partition_sizes = list(output_partition_sizes)
+        self._input_size = input_size
+        self._input_size_per_partition = input_size_per_partition
+        self._full_partition_sizes = list(full_partition_sizes)
+        self._params_dtype = params_dtype
 
-    def _convert_partition(self, qw, sc, qz, k, out_n):
-        """AWQ→Marlin conversion for a single partition via the parent method."""
-        # Pad output dim to Marlin tile boundary when needed.
-        if out_n % _MARLIN_TILE_N != 0:
-            pad = _MARLIN_TILE_N - out_n % _MARLIN_TILE_N
-            pack = self.quant_config.pack_factor
-            qw = torch.nn.functional.pad(qw, (0, pad // pack))
-            sc = torch.nn.functional.pad(sc, (0, pad))
-            qz = torch.nn.functional.pad(qz, (0, pad // pack))
-            out_n += pad
-
+    def _process_partition(
+        self,
+        qweight: torch.Tensor,
+        scales: torch.Tensor,
+        qzeros: torch.Tensor,
+        local_output_size: int,
+        full_output_size: int,
+    ) -> tuple[torch.nn.Module, Any]:
         proxy = torch.nn.Module()
-        proxy.register_parameter(
-            "qweight",
-            PackedvLLMParameter(
-                data=qw.contiguous(),
-                input_dim=0,
-                output_dim=1,
-                packed_dim=1,
-                packed_factor=self.quant_config.pack_factor,
-                weight_loader=None,
-            ),
-        )
-        proxy.register_parameter(
-            "scales", GroupQuantScaleParameter(data=sc.contiguous(), input_dim=0, output_dim=1, weight_loader=None)
-        )
-        proxy.register_parameter(
-            "qzeros",
-            PackedvLLMParameter(
-                data=qz.contiguous(),
-                input_dim=0,
-                output_dim=1,
-                packed_dim=1,
-                packed_factor=self.quant_config.pack_factor,
-                weight_loader=None,
-            ),
-        )
-        proxy.input_size_per_partition = k
-        proxy.output_size_per_partition = out_n
-        self.kernel.config.partition_weight_shape = (k, out_n)
-        super().process_weights_after_loading(proxy)
-        return proxy, deepcopy(self.kernel.workspace)
+        method = AutoAWQMarlinLinearMethod(self.quant_config)
+        method.input_dtype = self.input_dtype
+
+        with torch.device(qweight.device):
+            method.create_weights(
+                proxy,
+                input_size_per_partition=self._input_size_per_partition,
+                output_partition_sizes=[local_output_size],
+                input_size=self._input_size,
+                output_size=full_output_size,
+                params_dtype=self._params_dtype,
+            )
+
+        with torch.no_grad():
+            proxy.qweight.copy_(qweight)
+            proxy.scales.copy_(scales)
+            proxy.qzeros.copy_(qzeros)
+
+        method.process_weights_after_loading(proxy)
+        return proxy, method.kernel
+
+    @staticmethod
+    def _partition_state_name(partition: int, name: str) -> str:
+        return f"_paro_partition_{partition}_{name}"
+
+    def _install_partition_state(
+        self,
+        layer: torch.nn.Module,
+        partition: int,
+        proxy: torch.nn.Module,
+    ) -> _PartitionLayerView:
+        tensor_names: dict[str, str] = {}
+        values: dict[str, Any] = {}
+
+        for name, param in proxy._parameters.items():
+            if param is None:
+                values[name] = None
+                continue
+            root_name = self._partition_state_name(partition, name)
+            layer.register_parameter(root_name, param)
+            tensor_names[name] = root_name
+
+        for name, buffer in proxy._buffers.items():
+            if buffer is None:
+                values[name] = None
+                continue
+            root_name = self._partition_state_name(partition, name)
+            layer.register_buffer(root_name, buffer)
+            tensor_names[name] = root_name
+
+        for name, value in vars(proxy).items():
+            if name.startswith("_") or name in tensor_names or name in values:
+                continue
+            if isinstance(value, torch.Tensor):
+                root_name = self._partition_state_name(partition, name)
+                layer.register_buffer(root_name, value)
+                tensor_names[name] = root_name
+            else:
+                values[name] = value
+
+        return _PartitionLayerView(layer, tensor_names, values)
+
+    @staticmethod
+    def _refresh_kernel_state(active: Any, reloaded: Any) -> None:
+        if type(active) is not type(reloaded):
+            raise RuntimeError(
+                "ParoQuant selected a different linear kernel during reload: "
+                f"{type(active).__name__} -> {type(reloaded).__name__}."
+            )
+
+        if vars(active).keys() != vars(reloaded).keys():
+            raise RuntimeError("ParoQuant kernel state changed during reload.")
+
+        tensor_state: list[tuple[torch.Tensor, torch.Tensor]] = []
+        for name, new_value in vars(reloaded).items():
+            old_value = getattr(active, name)
+            if isinstance(old_value, torch.Tensor) or isinstance(
+                new_value, torch.Tensor
+            ):
+                if not (
+                    isinstance(old_value, torch.Tensor)
+                    and isinstance(new_value, torch.Tensor)
+                    and old_value.shape == new_value.shape
+                    and old_value.dtype == new_value.dtype
+                    and old_value.device == new_value.device
+                    and old_value.layout == new_value.layout
+                    and old_value.stride() == new_value.stride()
+                ):
+                    raise RuntimeError(
+                        "ParoQuant kernel tensor state changed during reload: "
+                        f"attribute {name!r}."
+                    )
+                tensor_state.append((old_value, new_value))
+            elif old_value != new_value:
+                raise RuntimeError(
+                    "ParoQuant kernel configuration changed during reload: "
+                    f"attribute {name!r}."
+                )
+
+        for old_value, new_value in tensor_state:
+            old_value.copy_(new_value)
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
-        n = layer.num_partitions
+        n = layer.paro_num_partitions
 
         if n == 1:
             super().process_weights_after_loading(layer)
         else:
+            from vllm.model_executor.offloader import NoopOffloader, get_offloader
+
+            if not isinstance(get_offloader(), NoopOffloader):
+                raise NotImplementedError(
+                    "Multipart ParoQuant weights cannot be registered after vLLM "
+                    "has configured model-weight offloading. Disable model-weight "
+                    "offloading for this checkpoint."
+                )
+
             pack = self.quant_config.pack_factor
-            sizes = layer.output_partition_sizes
-            k = layer.input_size_per_partition
+            sizes = layer.paro_output_partition_sizes
 
             qw = layer.qweight.data.split([s // pack for s in sizes], dim=1)
             sc = layer.scales.data.split(sizes, dim=1)
             qz = layer.qzeros.data.split([s // pack for s in sizes], dim=1)
 
-            proxies, workspaces = zip(*[self._convert_partition(qw[i], sc[i], qz[i], k, sizes[i]) for i in range(n)])
+            partitions: list[torch.nn.Module] = []
+            kernels: list[Any] = []
+            for i in range(n):
+                partition, kernel = self._process_partition(
+                    qw[i],
+                    sc[i],
+                    qz[i],
+                    sizes[i],
+                    self._full_partition_sizes[i],
+                )
+                partitions.append(partition)
+                kernels.append(kernel)
+
+            if self._partition_kernels:
+                if len(self._partition_kernels) != len(kernels):
+                    raise RuntimeError(
+                        "ParoQuant partition count changed during weight reload."
+                    )
+                for active, reloaded in zip(
+                    self._partition_kernels, kernels, strict=True
+                ):
+                    self._refresh_kernel_state(active, reloaded)
+
+            state_names = {
+                self._partition_state_name(i, name)
+                for i, partition in enumerate(partitions)
+                for name, value in (
+                    list(partition._parameters.items())
+                    + list(partition._buffers.items())
+                    + [
+                        (name, value)
+                        for name, value in vars(partition).items()
+                        if not name.startswith("_") and isinstance(value, torch.Tensor)
+                    ]
+                )
+                if value is not None
+            }
+            collisions = sorted(name for name in state_names if hasattr(layer, name))
+            if collisions:
+                raise RuntimeError(
+                    "ParoQuant partition state already exists before processing: "
+                    f"{collisions}."
+                )
 
             del layer.qweight, layer.scales, layer.qzeros
-            layer.marlin_qweight = [p.qweight for p in proxies]
-            layer.marlin_scales = [p.scales for p in proxies]
-            layer.marlin_qzeros = [p.qzeros for p in proxies]
-            layer.workspace = workspaces[0]
-            layer.g_idx = proxies[0].g_idx
-            layer.g_idx_sort_indices = proxies[0].g_idx_sort_indices
-            layer.padded_partition_sizes = [p.output_size_per_partition for p in proxies]
+            views = [
+                self._install_partition_state(layer, i, partition)
+                for i, partition in enumerate(partitions)
+            ]
+            if self._partition_views:
+                for active, reloaded in zip(self._partition_views, views, strict=True):
+                    active.refresh_values(reloaded)
+            else:
+                self._partition_views = views
+            if not self._partition_kernels:
+                self._partition_kernels = kernels
 
-        layer.rot_theta = layer.theta.data
-        layer.rot_pairs = layer.pairs.data
-        layer.rot_scales = layer.channel_scales.data
-        del layer.theta, layer.pairs, layer.channel_scales
-
-    def apply(self, layer: torch.nn.Module, x: torch.Tensor, bias: torch.Tensor | None = None) -> torch.Tensor:
-        n = layer.num_partitions
+    def apply(
+        self, layer: torch.nn.Module, x: torch.Tensor, bias: torch.Tensor | None = None
+    ) -> torch.Tensor:
+        n = layer.paro_num_partitions
 
         if n == 1:
-            x = torch.ops.rotation.rotate(x, layer.rot_pairs[0], layer.rot_theta[0], layer.rot_scales[0])
+            x = torch.ops.rotation.rotate(
+                x,
+                layer.pairs[0],
+                layer.theta[0],
+                layer.channel_scales[0],
+                self.quant_config.group_size,
+            )
             return super().apply(layer, x, bias)
 
         outputs = []
-        for i in range(n):
-            x_rot = torch.ops.rotation.rotate(x, layer.rot_pairs[i], layer.rot_theta[i], layer.rot_scales[i])
-            out = apply_awq_marlin_linear(
-                input=x_rot,
-                weight=layer.marlin_qweight[i],
-                weight_scale=layer.marlin_scales[i],
-                weight_zp=layer.marlin_qzeros[i],
-                g_idx=layer.g_idx,
-                g_idx_sort_indices=layer.g_idx_sort_indices,
-                workspace=layer.workspace,
-                quant_type=self.quant_config.quant_type,
-                output_size_per_partition=layer.padded_partition_sizes[i],
-                input_size_per_partition=layer.input_size_per_partition,
-                bias=None,
+        for i, (partition, kernel) in enumerate(
+            zip(self._partition_views, self._partition_kernels, strict=True)
+        ):
+            x_rot = torch.ops.rotation.rotate(
+                x,
+                layer.pairs[i],
+                layer.theta[i],
+                layer.channel_scales[i],
+                self.quant_config.group_size,
             )
-            if layer.padded_partition_sizes[i] != layer.output_partition_sizes[i]:
-                out = out[..., : layer.output_partition_sizes[i]]
-            outputs.append(out)
+            outputs.append(kernel.apply_weights(partition, x_rot, None))
 
         result = torch.cat(outputs, dim=-1)
         if bias is not None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ transformers = [
     "ninja",
 ]
 vllm = [
-    "vllm>=0.19.1,<0.20",
+    "vllm>=0.25.1,<0.26",
     "accelerate",
 ]
 mlx = [

--- a/tests/test_vllm_plugin.py
+++ b/tests/test_vllm_plugin.py
@@ -1,0 +1,235 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+
+import pytest
+import torch
+from torch.nn import Parameter
+
+from paroquant.inference.backends.vllm import plugin
+from paroquant.inference.backends.vllm.plugin import (
+    ParoQuantConfig,
+    _rotation_weight_loader,
+)
+
+
+def test_general_plugin_registration_keeps_cuda_extension_lazy() -> None:
+    code = """
+import importlib.metadata
+import os
+import sys
+
+os.environ["VLLM_PLUGINS"] = "paroquant"
+entry_points = [
+    ep
+    for ep in importlib.metadata.entry_points(group="vllm.general_plugins")
+    if ep.name == "paroquant"
+]
+assert len(entry_points) == 1
+assert "paroquant.inference.backends.vllm.generator" not in sys.modules
+assert "paroquant.inference.backends.vllm.plugin" not in sys.modules
+assert "paroquant.kernels.cuda" not in sys.modules
+
+import vllm.plugins
+
+vllm.plugins.plugins_loaded = False
+vllm.plugins.load_general_plugins()
+assert "paroquant.inference.backends.vllm.plugin" in sys.modules
+assert "paroquant.kernels.cuda" not in sys.modules
+
+from vllm.model_executor.layers.quantization import get_quantization_config
+from paroquant.inference.backends.vllm.plugin import ParoQuantConfig
+
+assert get_quantization_config("paroquant") is ParoQuantConfig
+vllm.plugins.load_general_plugins()
+assert "paroquant.kernels.cuda" not in sys.modules
+"""
+    subprocess.run([sys.executable, "-c", code], check=True)
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "match"),
+    [
+        ({"bits": 8}, "Unsupported bits"),
+        ({"group_size": 32}, "Unsupported group_size"),
+        ({"krot": 2}, "Unsupported krot"),
+    ],
+)
+def test_config_rejects_values_not_compiled_by_rotation_kernel(
+    kwargs: dict[str, int], match: str
+) -> None:
+    config = {"bits": 4, "group_size": 128, "krot": 8, "zero_point": True}
+    config.update(kwargs)
+    with pytest.raises(ValueError, match=match):
+        ParoQuantConfig(**config)
+
+
+def test_config_accepts_current_vllm_update_signature_and_scans_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = []
+
+    def metadata(*args, **kwargs):
+        calls.append((args, kwargs))
+        return {
+            "model.layers.0.float_proj.weight": {"dtype": "F16"},
+            "model.layers.0.float_proj.index_buffer": {"dtype": "I32"},
+            "model.layers.0.quant_proj.qweight": {"dtype": "I32"},
+            "model.layers.0.quant_proj.pairs": {"dtype": "I16"},
+            "model.layers.0.container.A_log": {"dtype": "F16"},
+        }
+
+    monkeypatch.setattr(plugin, "get_safetensors_params_metadata", metadata)
+    config = ParoQuantConfig.from_config({"bits": 4, "group_size": 128, "krot": 8})
+
+    config.maybe_update_config("model", hf_config=object(), revision="revision")
+    assert config.modules_to_not_convert == ["model.layers.0.float_proj"]
+    assert calls == [(("model",), {"revision": "revision"})]
+
+    config.maybe_update_config("model", hf_config=object(), revision="revision")
+    assert len(calls) == 1
+
+
+def test_explicit_empty_skip_list_is_not_rescanned(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def unexpected_scan(*args, **kwargs):
+        raise AssertionError("explicit modules_to_not_convert must not be rescanned")
+
+    monkeypatch.setattr(plugin, "get_safetensors_params_metadata", unexpected_scan)
+    config = ParoQuantConfig(
+        bits=4,
+        group_size=128,
+        krot=8,
+        zero_point=True,
+        modules_to_not_convert=[],
+    )
+
+    config.maybe_update_config("model", hf_config=object())
+    assert config.modules_to_not_convert == []
+
+
+def test_config_maps_explicit_skip_list() -> None:
+    class Mapper:
+        def apply_list(self, values):
+            return [f"mapped.{value}" for value in values]
+
+    config = ParoQuantConfig(
+        bits=4,
+        group_size=128,
+        krot=8,
+        zero_point=True,
+        modules_to_not_convert=["layers.0.float_proj"],
+    )
+
+    config.apply_vllm_mapper(Mapper())
+
+    assert config.modules_to_not_convert == ["mapped.layers.0.float_proj"]
+
+
+def test_paro_method_uses_current_weight_loader_and_marlin_input_dtype(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from vllm.model_executor.layers.linear import (
+        WEIGHT_LOADER_V2_SUPPORTED,
+        LinearBase,
+    )
+
+    class FakeMethod:
+        def __init__(self, quant_config):
+            self.quant_config = quant_config
+            self.input_dtype = None
+
+    monkeypatch.setattr(plugin, "ParoQuantLinearMethod", FakeMethod)
+    monkeypatch.setattr(
+        plugin, "check_marlin_supports_layer", lambda *args, **kwargs: True
+    )
+    monkeypatch.setattr(plugin, "get_marlin_input_dtype", lambda prefix: torch.int8)
+
+    layer = LinearBase(input_size=128, output_size=64, disable_tp=True)
+    config = ParoQuantConfig(
+        bits=4,
+        group_size=128,
+        krot=8,
+        zero_point=True,
+        modules_to_not_convert=[],
+    )
+    method = config.get_quant_method(layer, "layers.0.proj")
+
+    assert "ParoQuantLinearMethod" in WEIGHT_LOADER_V2_SUPPORTED
+    assert isinstance(method, FakeMethod)
+    assert method.input_dtype is torch.int8
+
+
+@pytest.mark.parametrize(
+    ("shard_id", "indices"),
+    [
+        ("q", [0]),
+        (1, [1]),
+        ((0, 2), [0, 2]),
+    ],
+)
+def test_rotation_loader_routes_fused_shards(
+    shard_id: int | str | tuple[int, ...], indices: list[int]
+) -> None:
+    param = Parameter(torch.zeros(3, 2, 8), requires_grad=False)
+    loaded = torch.arange(16, dtype=torch.float32).reshape(2, 8)
+
+    _rotation_weight_loader(param, loaded, shard_id)
+
+    for idx in range(3):
+        expected = loaded if idx in indices else torch.zeros_like(loaded)
+        torch.testing.assert_close(param[idx], expected)
+
+
+def test_rotation_loader_replicates_unsharded_fused_weight() -> None:
+    param = Parameter(torch.zeros(4, 2, 8), requires_grad=False)
+    loaded = torch.arange(16, dtype=torch.float32).reshape(2, 8)
+
+    _rotation_weight_loader(param, loaded)
+
+    for target in param:
+        torch.testing.assert_close(target, loaded)
+
+
+def test_rotation_loader_slices_row_parallel_input(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import vllm.distributed
+
+    monkeypatch.setattr(vllm.distributed, "get_tensor_model_parallel_rank", lambda: 1)
+    monkeypatch.setattr(
+        vllm.distributed, "get_tensor_model_parallel_world_size", lambda: 2
+    )
+    param = Parameter(torch.zeros(1, 2, 4), requires_grad=False)
+    loaded = torch.arange(16, dtype=torch.float32).reshape(2, 8)
+
+    _rotation_weight_loader(param, loaded)
+
+    torch.testing.assert_close(param[0], loaded[:, 4:])
+
+
+def test_rotation_loader_rejects_tp_shape_mismatch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import vllm.distributed
+
+    monkeypatch.setattr(vllm.distributed, "get_tensor_model_parallel_rank", lambda: 0)
+    monkeypatch.setattr(
+        vllm.distributed, "get_tensor_model_parallel_world_size", lambda: 4
+    )
+    param = Parameter(torch.zeros(1, 2, 4), requires_grad=False)
+    loaded = torch.zeros(2, 8)
+
+    with pytest.raises(ValueError, match="tensor-parallel world size"):
+        _rotation_weight_loader(param, loaded)
+
+
+@pytest.mark.parametrize("shard_id", ["invalid", -1, 3, (0, 4)])
+def test_rotation_loader_rejects_invalid_shard_ids(shard_id) -> None:
+    param = Parameter(torch.zeros(3, 2, 8), requires_grad=False)
+    loaded = torch.zeros(2, 8)
+
+    with pytest.raises(ValueError, match="invalid shard id"):
+        _rotation_weight_loader(param, loaded, shard_id)

--- a/tests/test_vllm_plugin_gpu.py
+++ b/tests/test_vllm_plugin_gpu.py
@@ -1,0 +1,390 @@
+from __future__ import annotations
+
+import contextlib
+import os
+import tempfile
+
+import pytest
+import torch
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_current_awq_kernel_single_and_multipart_differential() -> None:
+    from vllm.config import VllmConfig, set_current_vllm_config
+    from vllm.distributed import (
+        destroy_distributed_environment,
+        destroy_model_parallel,
+        init_distributed_environment,
+        initialize_model_parallel,
+    )
+    from paroquant.inference.backends.vllm.plugin import ParoQuantConfig
+
+    if torch.cuda.get_device_capability() < (7, 5):
+        pytest.skip("ParoQuant requires CUDA capability 7.5 or newer")
+
+    fd, store_path = tempfile.mkstemp()
+    os.close(fd)
+    torch.cuda.set_device(0)
+    torch.manual_seed(123)
+
+    try:
+        with set_current_vllm_config(VllmConfig()):
+            init_distributed_environment(
+                world_size=1,
+                rank=0,
+                distributed_init_method=f"file://{store_path}",
+                local_rank=0,
+                backend="nccl",
+            )
+            initialize_model_parallel(1, 1)
+
+            for parts in (
+                [64],
+                [64, 72],
+                [64, 72, 80],
+                [64, 72, 80, 88],
+            ):
+                _run_multipart_case(parts, ParoQuantConfig)
+            _run_layerwise_reload_case(ParoQuantConfig)
+    finally:
+        destroy_model_parallel()
+        destroy_distributed_environment()
+        with contextlib.suppress(OSError):
+            os.unlink(store_path)
+
+
+def _run_multipart_case(parts: list[int], config_type: type) -> None:
+    from vllm.model_executor.layers.linear import (
+        MergedColumnParallelLinear,
+        ReplicatedLinear,
+    )
+
+    input_size = 128
+    config = config_type(
+        bits=4,
+        group_size=128,
+        krot=1,
+        zero_point=True,
+        modules_to_not_convert=[],
+    )
+    with torch.device("cuda"):
+        fused = MergedColumnParallelLinear(
+            input_size=input_size,
+            output_sizes=parts,
+            bias=True,
+            params_dtype=torch.float16,
+            quant_config=config,
+            prefix="fused",
+            disable_tp=True,
+        )
+        singles = [
+            ReplicatedLinear(
+                input_size=input_size,
+                output_size=part_size,
+                bias=True,
+                params_dtype=torch.float16,
+                quant_config=config,
+                prefix=f"single_{index}",
+                disable_tp=True,
+            )
+            for index, part_size in enumerate(parts)
+        ]
+
+    with torch.no_grad():
+        fused.qweight.random_(-(2**31), 2**31 - 1)
+        fused.qzeros.zero_()
+        fused.scales.uniform_(0.001, 0.02)
+        fused.theta.zero_()
+        fused.channel_scales.fill_(1)
+        fused.pairs.copy_(
+            torch.arange(input_size, dtype=torch.int16, device="cuda")
+            .reshape(1, 1, input_size)
+            .expand(len(parts), -1, -1)
+        )
+        fused.bias.uniform_(-0.2, 0.2)
+        original_fused_bias = fused.bias.clone()
+
+        output_offset = 0
+        for index, (single, part_size) in enumerate(zip(singles, parts, strict=True)):
+            packed_offset = output_offset // config.pack_factor
+            packed_size = part_size // config.pack_factor
+            single.qweight.copy_(
+                fused.qweight[:, packed_offset : packed_offset + packed_size]
+            )
+            single.qzeros.copy_(
+                fused.qzeros[:, packed_offset : packed_offset + packed_size]
+            )
+            single.scales.copy_(
+                fused.scales[:, output_offset : output_offset + part_size]
+            )
+            single.theta.copy_(fused.theta[index : index + 1])
+            single.pairs.copy_(fused.pairs[index : index + 1])
+            single.channel_scales.copy_(fused.channel_scales[index : index + 1])
+            single.bias.copy_(fused.bias[output_offset : output_offset + part_size])
+            single.quant_method.process_weights_after_loading(single)
+            output_offset += part_size
+
+        fused.quant_method.process_weights_after_loading(fused)
+
+    x = torch.randn(7, input_size, device="cuda", dtype=torch.float16)
+    actual_without_bias = fused.quant_method.apply(fused, x, None)
+    expected_without_bias = torch.cat(
+        [single.quant_method.apply(single, x, None) for single in singles],
+        dim=-1,
+    )
+    actual = fused.quant_method.apply(fused, x, fused.bias)
+    expected = torch.cat(
+        [single.quant_method.apply(single, x, single.bias) for single in singles],
+        dim=-1,
+    )
+    torch.cuda.synchronize()
+
+    torch.testing.assert_close(
+        actual_without_bias, expected_without_bias, rtol=0, atol=0
+    )
+    torch.testing.assert_close(actual, expected, rtol=0.01, atol=0.002)
+    assert actual.shape == (7, sum(parts))
+    assert torch.isfinite(actual).all()
+
+    if len(parts) > 1:
+        torch.testing.assert_close(fused.bias, original_fused_bias, rtol=0, atol=0)
+        torch.testing.assert_close(
+            actual,
+            actual_without_bias + original_fused_bias,
+            rtol=0,
+            atol=0,
+        )
+        assert not hasattr(fused, "paro_partitions")
+        assert len(fused.quant_method._partition_views) == len(parts)
+        assert len(
+            {id(kernel) for kernel in fused.quant_method._partition_kernels}
+        ) == len(parts)
+        registered = dict(fused.named_parameters())
+        for index in range(len(parts)):
+            assert f"_paro_partition_{index}_qweight" in registered
+            assert f"_paro_partition_{index}_qzeros" in registered
+            assert f"_paro_partition_{index}_scales" in registered
+        assert "theta" in registered
+        assert "pairs" in registered
+        assert "channel_scales" in registered
+
+
+def _run_layerwise_reload_case(config_type: type) -> None:
+    from vllm.model_executor.layers.linear import (
+        MergedColumnParallelLinear,
+        ReplicatedLinear,
+    )
+    from vllm.model_executor.model_loader.reload.layerwise import (
+        finalize_layerwise_reload,
+        initialize_layerwise_reload,
+        record_metadata_for_reloading,
+    )
+
+    input_size = 128
+    parts = [64, 72]
+    config = config_type(
+        bits=4,
+        group_size=128,
+        krot=1,
+        zero_point=True,
+        modules_to_not_convert=[],
+    )
+    with torch.device("cuda"):
+        fused = MergedColumnParallelLinear(
+            input_size=input_size,
+            output_sizes=parts,
+            bias=True,
+            params_dtype=torch.float16,
+            quant_config=config,
+            prefix="reload_fused",
+            disable_tp=True,
+        )
+        model = torch.nn.Module()
+        model.add_module("fused", fused)
+        record_metadata_for_reloading(model)
+
+    with torch.no_grad():
+        fused.qweight.random_(-(2**31), 2**31 - 1)
+        fused.qzeros.zero_()
+        fused.scales.uniform_(0.001, 0.02)
+        fused.theta.zero_()
+        fused.channel_scales.fill_(1)
+        fused.pairs.copy_(
+            torch.arange(input_size, dtype=torch.int16, device="cuda")
+            .reshape(1, 1, input_size)
+            .expand(len(parts), -1, -1)
+        )
+        fused.bias.uniform_(-0.2, 0.2)
+        reload_weights = {
+            name: param.detach().clone()
+            for name, param in fused.named_parameters(recurse=False)
+        }
+        reload_weights["qweight"].random_(-(2**31), 2**31 - 1)
+        reload_weights["scales"].mul_(0.75)
+        fused.quant_method.process_weights_after_loading(fused)
+
+    parameter_ptrs = {
+        name: param.data_ptr() for name, param in fused.named_parameters(recurse=False)
+    }
+    buffer_ptrs = {
+        name: buffer.data_ptr() for name, buffer in fused.named_buffers(recurse=False)
+    }
+    partition_views = list(fused.quant_method._partition_views)
+    partition_value_ids = [id(view._values) for view in partition_views]
+    partition_kernels = list(fused.quant_method._partition_kernels)
+    kernel_config_ids = [id(kernel.config) for kernel in partition_kernels]
+    workspace_ptrs = [kernel.workspace.data_ptr() for kernel in partition_kernels]
+
+    static_x = torch.randn(5, input_size, device="cuda", dtype=torch.float16)
+    compile_count = 0
+
+    def counting_backend(graph_module, _example_inputs):
+        nonlocal compile_count
+        compile_count += 1
+        return graph_module.forward
+
+    compiled_apply = torch.compile(
+        lambda value: fused.quant_method.apply(fused, value, fused.bias),
+        backend=counting_backend,
+        fullgraph=True,
+    )
+    compiled_output = compiled_apply(static_x)
+    assert compile_count == 1
+
+    capture_stream = torch.cuda.Stream()
+    capture_stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(capture_stream):
+        for _ in range(2):
+            fused.quant_method.apply(fused, static_x, fused.bias)
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            graph_output = fused.quant_method.apply(fused, static_x, fused.bias)
+    torch.cuda.current_stream().wait_stream(capture_stream)
+    graph.replay()
+    torch.cuda.synchronize()
+    original_graph_output = graph_output.clone()
+
+    def reload_and_check_pointers() -> None:
+        initialize_layerwise_reload(model)
+        restored_names = {name for name, _ in fused.named_parameters(recurse=False)}
+        assert restored_names == set(reload_weights)
+        for name, param in list(fused.named_parameters(recurse=False)):
+            param.weight_loader(param, reload_weights[name])
+        finalize_layerwise_reload(model, None)
+
+        assert parameter_ptrs == {
+            name: param.data_ptr()
+            for name, param in fused.named_parameters(recurse=False)
+        }
+        assert buffer_ptrs == {
+            name: buffer.data_ptr()
+            for name, buffer in fused.named_buffers(recurse=False)
+        }
+        assert all(
+            active is original
+            for active, original in zip(
+                fused.quant_method._partition_views, partition_views, strict=True
+            )
+        )
+        assert all(
+            active is original
+            for active, original in zip(
+                fused.quant_method._partition_kernels,
+                partition_kernels,
+                strict=True,
+            )
+        )
+        assert workspace_ptrs == [
+            kernel.workspace.data_ptr() for kernel in partition_kernels
+        ]
+        assert partition_value_ids == [
+            id(view._values) for view in fused.quant_method._partition_views
+        ]
+        assert kernel_config_ids == [
+            id(kernel.config) for kernel in fused.quant_method._partition_kernels
+        ]
+
+    reload_and_check_pointers()
+    torch.testing.assert_close(
+        compiled_apply(static_x),
+        fused.quant_method.apply(fused, static_x, fused.bias),
+        rtol=0,
+        atol=0,
+    )
+    assert compile_count == 1
+    graph.replay()
+    torch.cuda.synchronize()
+    first_reload_graph_output = graph_output.clone()
+
+    reload_weights["scales"].mul_(0.8)
+    reload_and_check_pointers()
+    torch.testing.assert_close(
+        compiled_apply(static_x),
+        fused.quant_method.apply(fused, static_x, fused.bias),
+        rtol=0,
+        atol=0,
+    )
+    assert compile_count == 1
+
+    with torch.device("cuda"):
+        references = [
+            ReplicatedLinear(
+                input_size=input_size,
+                output_size=part_size,
+                bias=True,
+                params_dtype=torch.float16,
+                quant_config=config,
+                prefix=f"reload_reference_{index}",
+                disable_tp=True,
+            )
+            for index, part_size in enumerate(parts)
+        ]
+
+    with torch.no_grad():
+        output_offset = 0
+        for index, (reference, part_size) in enumerate(
+            zip(references, parts, strict=True)
+        ):
+            packed_offset = output_offset // config.pack_factor
+            packed_size = part_size // config.pack_factor
+            reference.qweight.copy_(
+                reload_weights["qweight"][
+                    :, packed_offset : packed_offset + packed_size
+                ]
+            )
+            reference.qzeros.copy_(
+                reload_weights["qzeros"][:, packed_offset : packed_offset + packed_size]
+            )
+            reference.scales.copy_(
+                reload_weights["scales"][:, output_offset : output_offset + part_size]
+            )
+            reference.theta.copy_(reload_weights["theta"][index : index + 1])
+            reference.pairs.copy_(reload_weights["pairs"][index : index + 1])
+            reference.channel_scales.copy_(
+                reload_weights["channel_scales"][index : index + 1]
+            )
+            reference.bias.copy_(
+                reload_weights["bias"][output_offset : output_offset + part_size]
+            )
+            reference.quant_method.process_weights_after_loading(reference)
+            output_offset += part_size
+
+    actual_without_bias = fused.quant_method.apply(fused, static_x, None)
+    expected_without_bias = torch.cat(
+        [
+            reference.quant_method.apply(reference, static_x, None)
+            for reference in references
+        ],
+        dim=-1,
+    )
+    eager_output = fused.quant_method.apply(fused, static_x, fused.bias)
+    graph.replay()
+    torch.cuda.synchronize()
+
+    torch.testing.assert_close(
+        actual_without_bias, expected_without_bias, rtol=0, atol=0
+    )
+    torch.testing.assert_close(graph_output, eager_output, rtol=0, atol=0)
+    assert not torch.equal(compiled_output, eager_output)
+    assert not torch.equal(original_graph_output, graph_output)
+    assert not torch.equal(first_reload_graph_output, graph_output)


### PR DESCRIPTION
## Problem

ParoQuant models cannot be served with vLLM 0.25.1. Plugin discovery fails while importing the removed `AWQMarlinLinearMethod`, so the `paroquant` quantization method is never registered. Registration also imports the generator and CUDA extension before a ParoQuant linear layer is created.

## Root cause

The backend still targets the vLLM 0.19.x AWQ-Marlin API and dependency range. Its fused-projection conversion also manages Marlin state outside the current weight-loader and layerwise-reload contracts, which can replace tensor storage referenced by `torch.compile` or a captured CUDA graph.

## Fix

- Update the optional dependency to `vllm>=0.25.1,<0.26` and align the README, generated model-card instructions, and Docker chat/serve build pins with vLLM 0.25.1.
- Keep general-plugin discovery lazy; load the CUDA extension only when `ParoQuantLinearMethod` is instantiated.
- Port the backend to `AutoAWQMarlinLinearMethod`, weight-loader v2, and current Marlin tile-padding and input-dtype selection.
- Process each fused logical projection with an independent current Marlin kernel, preserve partition order, and apply the fused bias once.
- Store transformed multipart tensors on the owning linear layer and preserve their pointers across layerwise reload.
- Detect unquantized checkpoint leaves from exact `*.qweight` metadata before applying vLLM's model mapper.
- Reject unsupported tensor-parallel grouping and multipart model-weight offloading instead of silently selecting an invalid fallback.

No vLLM source, package, or environment changes are required.

## Verification

- `python -m pytest -q tests/test_vllm_plugin.py tests/test_vllm_plugin_gpu.py`: `19 passed`.
- GPU coverage includes single and 2/3/4-part fused Marlin output, bias handling, two layerwise reloads, stable parameter/buffer/kernel/workspace pointers, no `torch.compile` recompilation, and replay of a CUDA graph captured before reload.
- Compatibility was validated against the vLLM 0.25.1 interfaces and the current integration tree.
- An end-to-end ParoQuant checkpoint load and chat-completion smoke test returned HTTP 200.
- `ruff format --check`, `ruff check`, `python -m compileall -q`, and `git diff --check` passed for the changed files.
